### PR TITLE
Fix bugs the HeartBeat class, which was generating long periods between heartbeats

### DIFF
--- a/src/central_node_engine.cc
+++ b/src/central_node_engine.cc
@@ -1029,7 +1029,7 @@ void Engine::engineThread()
     std::cout << "INFO: Engine: update thread started." << std::endl;
 
     // Declare as real time task
-    param.sched_priority = 70;
+    param.sched_priority = 75;
     if(sched_setscheduler(0, SCHED_FIFO, &param) == -1)
     {
         perror("Set priority");

--- a/src/central_node_engine.h
+++ b/src/central_node_engine.h
@@ -136,7 +136,7 @@ private:
     Timer<double>  _evaluationCycleTime;
 
     // Heartbeat control class
-    HeartBeat hb;
+    NonBlockingHeartBeat hb;
 
 public:
     static Engine &getInstance()

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -114,7 +114,7 @@ void HeartBeat::beatWriter()
             }
         }
 
-        // Start the TX duration Timer
+        // Start the TX duration timer
         txDuration.start();
 
         // Check if there was a WD error, and increase counter accordingly
@@ -126,9 +126,6 @@ void HeartBeat::beatWriter()
         // Set heartbeat bit
         swHeartBeat->execute();
 
-        // Tick the duration timer
-        txDuration.tick();
-
         // Tick period timer;
         txPeriod.tick();
 
@@ -136,6 +133,9 @@ void HeartBeat::beatWriter()
         ++hbCnt;
 
         beatReq = false;
+
+        // Tick the TX duration timer
+        txDuration.tick();
     }
 }
 #endif

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -1,56 +1,29 @@
 #include "heartbeat.h"
 
 #ifdef FW_ENABLED
-HeartBeat::HeartBeat( Path root, const uint32_t& timeout, size_t timerBufferSize )
+template <typename BeatPolicy>
+HeartBeat<BeatPolicy>::HeartBeat( Path root, const uint32_t& timeout, size_t timerBufferSize )
 :
-    txPeriod      ( "Time Between Heartbeats", timerBufferSize ),
-    txDuration    ( "Time to send Heartbeats", timerBufferSize ),
+    BeatPolicy    ( root, timerBufferSize ),
     swWdTime      ( IScalVal::create    ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareWdTime" ) ) ),
-    swWdError     ( IScalVal_RO::create ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareWdError" ) ) ),
-    swHbCntMax    ( IScalVal_RO::create ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareHbUpCntMax" ) ) ),
-    swHeartBeat   ( ICommand::create     ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SwHeartbeat" ) ) ),
-    hbCnt         ( 0 ),
-    wdErrorCnt    ( 0 ),
-    reqTimeoutCnt ( 0 ),
-    reqTimeout    ( 5 ),
-    beatReq       ( false ),
-    run           ( true ),
-    beatThread    ( std::thread( &HeartBeat::beatWriter, this ) )
+    swHbCntMax    ( IScalVal_RO::create ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareHbUpCntMax" ) ) )
 {
     printf("\n");
     printf("Central Node HeartBeat started.\n");
     swWdTime->setVal( timeout );
     printf("Software Watchdog timer set to: %" PRIu32 "\n", timeout);
-
-    if( pthread_setname_np( beatThread.native_handle(), "HeartBeat" ) )
-        perror( "pthread_setname_np failed for HeartBeat thread" );
 }
 
-HeartBeat::~HeartBeat()
+template<typename BeatPolicy>
+HeartBeat<BeatPolicy>::~HeartBeat()
 {
-    // Stop the heartbeat thread
-    run = false;
-    beatThread.join();
-
     // Print final report
     printReport();
     std::cout << std::flush;
 }
 
-void HeartBeat::clear()
-{
-    // Wait for any heartbeat generation in progress
-    std::unique_lock<std::mutex> lock(beatMutex);
-    beatCondVar.wait( lock, std::bind(&HeartBeat::predN, this) );
-
-    txPeriod.clear();
-    txDuration.clear();
-    hbCnt = 0;
-    wdErrorCnt = 0;
-    reqTimeoutCnt = 0;
-}
-
-void HeartBeat::printReport()
+template<typename BeatPolicy>
+void HeartBeat<BeatPolicy>::printReport()
 {
     printf( "\n" );
     printf( "HeartBeat report:\n" );
@@ -58,43 +31,143 @@ void HeartBeat::printReport()
     uint32_t u32;
     swWdTime->getVal( &u32 );
     printf( "Software watchdog timer       : %" PRIu32 " us\n", u32 );
-    printf( "Request timeout               : %zu ms\n", reqTimeout );
-    printf( "Heartbeat count               : %d\n",    hbCnt );
-    printf( "Software watchdog error count : %d\n",    wdErrorCnt );
-    printf( "Timeouts waiting for requests : %zu\n",   reqTimeoutCnt );
-    if ( 0 != hbCnt)
-    {
-        // Print the maximum period measured by the FW application
-        uint32_t u32;
-        swHbCntMax->getVal(&u32);
-        printf( "Maximum period between heartbeats (FW)  : %zu us\n", u32/fpgaClkPerUs );
-
-        printf( "Maximum period between heartbeats (All) : %f us\n", ( txPeriod.getAllMaxPeriod()   * 1000000 ) );
-        printf( "Maximum period between heartbeats       : %f us\n", ( txPeriod.getMaxPeriod()      * 1000000 ) );
-        printf( "Average period between heartbeats       : %f us\n", ( txPeriod.getMeanPeriod()     * 1000000 ) );
-        printf( "Minimum period between heartbeats       : %f us\n", ( txPeriod.getMinPeriod()      * 1000000 ) );
-        printf( "Maximum period to send heartbeats (All) : %f us\n", ( txDuration.getAllMaxPeriod() * 1000000 ) );
-        printf( "Maximum period to send heartbeats       : %f us\n", ( txDuration.getMaxPeriod()    * 1000000 ) );
-        printf( "Average period to send heartbeats       : %f us\n", ( txDuration.getMeanPeriod()   * 1000000 ) );
-        printf( "Minimum period to send heartbeats       : %f us\n", ( txDuration.getMinPeriod()    * 1000000 ) );
-    }
-    printf( "===============================================\n" );
-    printf( "\n" );
+    swHbCntMax->getVal(&u32);
+    printf( "Maximum heartbeat period (FW) : %zu us\n", u32/fpgaClkPerUs );
+    this->printBeatReport();
 }
 
-void HeartBeat::setWdTime( const uint32_t& timeout )
+template<typename BeatPolicy>
+void HeartBeat<BeatPolicy>::setWdTime( const uint32_t& timeout )
 {
     swWdTime->setVal( timeout );
 }
 
-void HeartBeat::beat()
+////////////////////////////////
+// BeatBase class definitions //
+////////////////////////////////
+BeatBase::BeatBase(Path root, size_t timerBufferSize)
+:
+    txPeriod      ( "Time Between Heartbeats", timerBufferSize ),
+    txDuration    ( "Time to send Heartbeats", timerBufferSize ),
+    swWdError     ( IScalVal_RO::create ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareWdError" ) ) ),
+    swHeartBeat   ( ICommand::create     ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SwHeartbeat" ) ) ),
+    hbCnt         ( 0 ),
+    wdErrorCnt    ( 0 )
 {
+}
+
+void BeatBase::defaultClear()
+{
+    txPeriod.clear();
+    txDuration.clear();
+    hbCnt = 0;
+    wdErrorCnt = 0;
+}
+
+void BeatBase::defaultBeat()
+{
+    // Start the TX duration timer
+    txDuration.start();
+
+    // Check if there was a WD error, and increase counter accordingly
+    uint32_t u32;
+    swWdError->getVal(&u32);
+    if (u32)
+        ++wdErrorCnt;
+
+    // Set heartbeat bit
+    swHeartBeat->execute();
+
+    // Tick period timer;
+    txPeriod.tick();
+
+    // Increase counter
+    ++hbCnt;
+
+    // Tick the TX duration timer
+    txDuration.tick();
+}
+
+void BeatBase::defaultPrintReport()
+{
+    printf( "Heartbeat count               : %d\n",    hbCnt );
+    printf( "Software watchdog error count : %d\n",    wdErrorCnt );
+    txPeriod.show();
+    txDuration.show();
+}
+
+////////////////////////////////////
+// BlockingBeat class definitions //
+////////////////////////////////////
+BlockingBeat::BlockingBeat(Path root, size_t timerBufferSize)
+:
+    BeatBase ( root, timerBufferSize )
+{
+}
+
+void BlockingBeat::clear()
+{
+    defaultClear();
+}
+
+void BlockingBeat::beat()
+{
+    defaultBeat();
+}
+
+void BlockingBeat::printBeatReport()
+{
+    defaultPrintReport();
+}
+
+///////////////////////////////////////
+// NonBlockingBeat class definitions //
+///////////////////////////////////////
+NonBlockingBeat::NonBlockingBeat(Path root, size_t timerBufferSize)
+:
+    BeatBase      ( root, timerBufferSize ),
+    reqTimeoutCnt ( 0 ),
+    reqTimeout    ( 5 ),
+    beatReq       ( false ),
+    run           ( true ),
+    beatThread    ( std::thread( &NonBlockingBeat::beatWriter, this ) )
+{
+    if( pthread_setname_np( beatThread.native_handle(), "HeartBeat" ) )
+       perror( "pthread_setname_np failed for HeartBeat thread" );
+}
+
+NonBlockingBeat::~NonBlockingBeat()
+{
+    // Stop the heartbeat thread
+    run = false;
+    beatThread.join();
+}
+
+void NonBlockingBeat::clear()
+{
+    // Wait for any heartbeat generation in progress
+    std::unique_lock<std::mutex> lock(beatMutex);
+    beatCondVar.wait( lock, std::bind(&NonBlockingBeat::predN, this) );
+
+    defaultClear();
+
+    reqTimeoutCnt = 0;
+}
+
+void NonBlockingBeat::beat()
+{
+    // Wait for any heartbeat generation in progress
+    {
+        std::unique_lock<std::mutex> lock(beatMutex);
+        beatCondVar.wait( lock, std::bind(&NonBlockingBeat::predN, this) );
+    }
+
     std::unique_lock<std::mutex> lock(beatMutex);
     beatReq = true;
     beatCondVar.notify_one();
 }
 
-void HeartBeat::beatWriter()
+void NonBlockingBeat::beatWriter()
 {
     std::cout << "Heartbeat writer thread started..." << std::endl;
 
@@ -111,35 +184,16 @@ void HeartBeat::beatWriter()
     {
         // Wait for a request
         std::unique_lock<std::mutex> lock(beatMutex);
-        if (beatCondVar.wait_for(lock, std::chrono::milliseconds(reqTimeout), std::bind(&HeartBeat::pred, this)))
+        if (beatCondVar.wait_for(lock, std::chrono::milliseconds(reqTimeout), std::bind(&NonBlockingBeat::pred, this)))
         {
-            // Start the TX duration timer
-            txDuration.start();
-
-            // Check if there was a WD error, and increase counter accordingly
-            uint32_t u32;
-            swWdError->getVal(&u32);
-            if (u32)
-                ++wdErrorCnt;
-
-            // Set heartbeat bit
-            swHeartBeat->execute();
-
-            // Tick period timer;
-            txPeriod.tick();
-
-            // Increase counter
-            ++hbCnt;
-
-            // Tick the TX duration timer
-            txDuration.tick();
+            defaultBeat();
 
             // Notify that we are done with the heartbeat generation.
             // Manual unlocking is done before notifying, to avoid waking up
             // the waiting thread only to block again (see notify_one for details)
             beatReq = false;
             lock.unlock();
-            beatCondVar.notify_one();
+            beatCondVar.notify_all();
         }
         else
         {
@@ -154,4 +208,16 @@ void HeartBeat::beatWriter()
         }
     }
 }
+
+void NonBlockingBeat::printBeatReport()
+{
+    printf( "Request timeout               : %zu ms\n", reqTimeout );
+    printf( "Timeouts waiting for requests : %zu\n",   reqTimeoutCnt );
+    defaultPrintReport();
+}
+
+// Explicit template instantiations
+template class HeartBeat<BlockingBeat>;
+template class HeartBeat<NonBlockingBeat>;
+
 #endif

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -100,7 +100,7 @@ void HeartBeat::beatWriter()
 
     // Declare as real time task
     struct sched_param  param;
-    param.sched_priority = 20;
+    param.sched_priority = 74;
     if(sched_setscheduler(0, SCHED_FIFO, &param) == -1)
     {
         perror("Set priority");

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -34,6 +34,7 @@ HeartBeat::~HeartBeat()
 
     // Print final report
     printReport();
+    std::cout << std::flush;
 }
 
 void HeartBeat::clear()

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -98,21 +98,19 @@ void HeartBeat::beatWriter()
 
     for(;;)
     {
+        // Wait for a request
+        std::unique_lock<std::mutex> lock(beatMutex);
+        while(!beatReq)
         {
-            // Wait for a request
-            std::unique_lock<std::mutex> lock(beatMutex);
-            while(!beatReq)
+            beatCondVar.wait_for( lock, std::chrono::milliseconds(reqTimeout) );
+
+            if (!beatReq)
+                ++reqTimeoutCnt;
+
+            if(!run)
             {
-                beatCondVar.wait_for( lock, std::chrono::milliseconds(reqTimeout) );
-
-                if (!beatReq)
-                    ++reqTimeoutCnt;
-
-                if(!run)
-                {
-                    std::cout << "Heartbeat writer thread interrupted" << std::endl;
-                    return;
-                }
+                std::cout << "Heartbeat writer thread interrupted" << std::endl;
+                return;
             }
         }
 

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -7,6 +7,7 @@ HeartBeat::HeartBeat( Path root, const uint32_t& timeout, size_t timerBufferSize
     txDuration    ( "Time to send Heartbeats", timerBufferSize ),
     swWdTime      ( IScalVal::create    ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareWdTime" ) ) ),
     swWdError     ( IScalVal_RO::create ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareWdError" ) ) ),
+    swHbCntMax    ( IScalVal_RO::create ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SoftwareHbUpCntMax" ) ) ),
     swHeartBeat   ( ICommand::create     ( root->findByName( "/mmio/MpsCentralApplication/MpsCentralNodeCore/SwHeartbeat" ) ) ),
     hbCnt         ( 0 ),
     wdErrorCnt    ( 0 ),
@@ -58,6 +59,11 @@ void HeartBeat::printReport()
     printf( "Timeouts waiting for requests : %zu\n",   reqTimeoutCnt );
     if ( 0 != hbCnt)
     {
+        // Print the maximum period measured by the FW application
+        uint32_t u32;
+        swHbCntMax->getVal(&u32);
+        printf( "Maximum period between heartbeats (FW)  : %zu us\n", u32/fpgaClkPerUs );
+
         printf( "Maximum period between heartbeats (All) : %f us\n", ( txPeriod.getAllMaxPeriod()   * 1000000 ) );
         printf( "Maximum period between heartbeats       : %f us\n", ( txPeriod.getMaxPeriod()      * 1000000 ) );
         printf( "Average period between heartbeats       : %f us\n", ( txPeriod.getMeanPeriod()     * 1000000 ) );

--- a/src/heartbeat.h
+++ b/src/heartbeat.h
@@ -14,16 +14,51 @@
 
 #include "timer.h"
 
-class HeartBeat
+template <typename BeatPolicy>
+class HeartBeat;
+
+// Policy classes
+class BlockingBeat;
+class NonBlockingBeat;
+
+// Convenience typdedef
+typedef HeartBeat<BlockingBeat>    BlockingHeartBeat;
+typedef HeartBeat<NonBlockingBeat> NonBlockingHeartBeat;
+
+template <typename BeatPolicy>
+class HeartBeat : public BeatPolicy
 {
 public:
     HeartBeat( Path root, const uint32_t& timeout=3500, size_t timerBufferSize=360 );
     ~HeartBeat();
-    void beat();
-    void setWdTime( const uint32_t& timeout );
 
+    void setWdTime( const uint32_t& timeout );
     void printReport();
-    void clear();
+
+private:
+    // FPGA clocks per microsecond. Used to convert the
+    // maximum heartbeat period measured by the FW application.
+    static const std::size_t fpgaClkPerUs = 250;
+
+    ScalVal                 swWdTime;
+    ScalVal_RO              swHbCntMax;
+};
+
+
+// Policy classes to define the type of heartbeat implementation
+
+// Base policy class: contains all common functionality and interfaces
+// to all the policy classes.
+class BeatBase
+{
+public:
+    BeatBase(Path root, size_t timerBufferSize);
+    virtual ~BeatBase() {};
+
+    virtual void beat() = 0;
+    virtual void clear() = 0;
+    virtual void printBeatReport() = 0;
+
     int  getWdErrorCnt() const       { return wdErrorCnt; };
 
     const double getMinTxPeriod()    { return txPeriod.getMinPeriod();  };
@@ -34,19 +69,49 @@ public:
     const double getMaxTxDuration()  { return txDuration.getAllMaxPeriod();  };
     const double getMeanTxDuration() { return txDuration.getMeanPeriod(); };
 
-private:
-    // FPGA clocks per microsecond. Used to convert the
-    // maximum heartbeat period measured by the FW application.
-    static const std::size_t fpgaClkPerUs = 250;
+protected:
+    // Some default implementation which could be used by several derived classes
+    void defaultBeat();
+    void defaultClear();
+    void defaultPrintReport();
 
-    Timer<double>           txPeriod;
-    Timer<double>           txDuration;
-    ScalVal                 swWdTime;
-    ScalVal_RO              swWdError;
-    ScalVal_RO              swHbCntMax;
-    Command                 swHeartBeat;
-    int                     hbCnt;
-    int                     wdErrorCnt;
+private:
+    Timer<double> txPeriod;
+    Timer<double> txDuration;
+    ScalVal_RO    swWdError;
+    Command       swHeartBeat;
+    int           hbCnt;
+    int           wdErrorCnt;
+};
+
+// Blocking beat policy class: this class send heratbeat in the foreground, so the
+// call to the 'beat' method will block and return after the heartbeat command is
+// sent to the FW.
+class BlockingBeat : public BeatBase
+{
+public:
+    BlockingBeat(Path root, size_t timerBufferSize);
+    virtual ~BlockingBeat() {};
+
+    virtual void beat();
+    virtual void clear();
+    virtual void printBeatReport();
+};
+
+// Non blocking beat policy class: this class send heartbeat on a background thread,
+// so the call to the 'beat' method will return before the hearbeat command is sent
+// to the FW.
+class NonBlockingBeat : public BeatBase
+{
+public:
+    NonBlockingBeat(Path root, size_t timerBufferSize);
+    virtual ~NonBlockingBeat();
+
+    virtual void beat();
+    virtual void clear();
+    virtual void printBeatReport();
+
+private:
     std::size_t             reqTimeoutCnt;
     std::size_t             reqTimeout;
     bool                    beatReq;
@@ -55,7 +120,7 @@ private:
     boost::atomic<bool>     run;
     std::thread             beatThread;
 
-    void        beatWriter();
+    void beatWriter();
 
     // Helper predicate functions used for the conditional variable
     // 'wait_for' methods. We need this as our old rhel6 host don't

--- a/src/heartbeat.h
+++ b/src/heartbeat.h
@@ -34,10 +34,15 @@ public:
     const double getMeanTxDuration() { return txDuration.getMeanPeriod(); };
 
 private:
+    // FPGA clocks per microsecond. Used to convert the
+    // maximum heartbeat period measured by the FW application.
+    static const std::size_t fpgaClkPerUs = 250;
+
     Timer<double>           txPeriod;
     Timer<double>           txDuration;
     ScalVal                 swWdTime;
     ScalVal_RO              swWdError;
+    ScalVal_RO              swHbCntMax;
     Command                 swHeartBeat;
     int                     hbCnt;
     int                     wdErrorCnt;

--- a/src/heartbeat.h
+++ b/src/heartbeat.h
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <chrono>
 #include <thread>
+#include <functional>
 #include <boost/atomic.hpp>
 #include <cpsw_api_user.h>
 
@@ -55,6 +56,12 @@ private:
     std::thread             beatThread;
 
     void        beatWriter();
+
+    // Helper predicate functions used for the conditional variable
+    // 'wait_for' methods. We need this as our old rhel6 host don't
+    // support C++11 , otherwise we could have used lambda expressions.
+    bool pred()  { return beatReq;  };
+    bool predN() { return !beatReq; };
 };
 
 #endif

--- a/src/test/central_node_watchdog_tst.cc
+++ b/src/test/central_node_watchdog_tst.cc
@@ -56,16 +56,16 @@ public:
     ~Tester();
 
 private:
-    ScalVal             enable;
-    ScalVal             swEnable;
-    Stream              strm0;
-    Stream              strm1;
-    Command             swErrClr;
-    HeartBeat           hb;
-    Timer<double>       rxT;
-    boost::atomic<bool> run;
-    std::thread         rxThreadMain;
-    std::thread         rxThreadSecondary;
+    ScalVal              enable;
+    ScalVal              swEnable;
+    Stream               strm0;
+    Stream               strm1;
+    Command              swErrClr;
+    NonBlockingHeartBeat hb;
+    Timer<double>        rxT;
+    boost::atomic<bool>  run;
+    std::thread          rxThreadMain;
+    std::thread          rxThreadSecondary;
 
     void rxHandlerMain();
     void rxHandlerSecondary();


### PR DESCRIPTION
This PR fixes a bug in the `HeartBeat` class, where a shared variable was not protected correctly by its corresponding mutex, and was therefore causing the silently lost of beat commands, resulting in longer that expected (~ twice) period between heartbeat commands. This issue causes the FW watchdog to not be rested before its timeout; the workaround so fas had been increasing the watchdog timeout to `7 us`. 

Also, the RT priority of the heartbeat thread was adjusted. 

With these fixes the period between heartbeat is as expected, `<= 3.5ms` approximately. 

Additionally, the `HeartBeat` class was broken down into policy classes which define the mode of sending the heartbeat commands to the FW:
- `Blocking`: the commands are send in the foreground, blocking the calling thread until the command is send to the FW.
- `Non-blocking`: the command is send to the FW in a background thread, so the calling thread doesn't have to wait for the command to the processed. This is the mode that is currently used.

Finally, I also updated both watchdog test applications.

https://jira.slac.stanford.edu/browse/ESLMPS-113