### PR TITLE
Improve evaluation processing pipeline 

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -9,6 +9,33 @@
 #  Rev:  dd-mmm-yyyy, Reviewer's Name    (USERNAME)
 #--------------------------------------------------------------
 
+  * Adjust RT priorities of all the evaluation threads as described in this
+    table (note that the NIC kernel thread priorities are not set as part of
+    this repository, but instead on the CPU startup script):
+    | Thread               | Priority |
+    |----------------------|----------|
+    | NIC (kernel)         |    80    |
+    | CPSW: UDP            |    81    |
+    | CPSW: RSSI           |    82    |
+    | CPSW: Depack         |    83    |
+    | CPSW: TDESTMux       |    84    |
+    | Engine: FwReader     |    85    |
+    | Engine: InputUpdates |    86    |
+    | Engine: HeartBeat    |    87    |
+    | Engine: MitWriter    |    87    |
+    | Engine: EngineThread |    88    |
+  * Add a thread-safe `Queue` class.
+  * Migrate the update input and the mitigation shared buffers to a `Queue`
+    object. This will give the system more elasticity to absorb delays between
+    threads, instead of blocking the whole pipeline.
+  * heartbeat: modify the `NonBlocking` policy class to keep a request counter,
+    instead of a flag, in order to avoid blocking the requesting thread in case
+    the previous heartbeat takes longer than `2.7ms` to write the FW register.
+  * Bug fix on central_node_database: inputProcessed() should lock the `mutex` and
+    notify using the `condition_variable`.
+  * Add name to the `fwPCChangeThread` thread.
+  * Fix format on some source files to improve readability.
+
 central_node_engine-R1-8-0:
   * Implement power class change asynchronous notification message
     handler.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,8 @@
-#==============================================================
-#
-#  Name: RELEASE_NOTES
-#
-#  Rem:  This files describes release notes for
-#        the XXX IOC Application.
-#
-#  Auth: xx-Dec-2012, XXX         (xxx)
-#  Rev:  dd-mmm-yyyy, Reviewer's Name    (USERNAME)
-#--------------------------------------------------------------
+# RELEASE_NOTES
+
+Release notes for the LCLS-II MPS central node engine.
+
+## Releases:
 
   * Adjust RT priorities of all the evaluation threads as described in this
     table (note that the NIC kernel thread priorities are not set as part of
@@ -36,67 +31,66 @@
   * Add name to the `fwPCChangeThread` thread.
   * Fix format on some source files to improve readability.
 
-central_node_engine-R1-8-0:
+__central_node_engine-R1-8-0__:
   * Implement power class change asynchronous notification message
     handler.
   * Fix bugs the HeartBeat class, which was generating long periods
     between heartbeats.
   * Fix bugs and improve the CN engine.
 
-central_node_engine-R1-7-0:
+__central_node_engine-R1-7-0__:
   * Update buildroot to version 2019.08.
   * Update CPSW to version R4.4.1. This implied update boost to version
     1.64.0 and yaml-cpp to version yaml-cpp-0.5.3_boost-1.64.0.
   * Fix all compilation warnings.
   * Merge changes from the EIC branch.
 
-central_node_engine-R1-6-0-eic:
+__central_node_engine-R1-6-0-eic__:
   * Changed logic to allow AOM
   * Bug fixed on the FW configuration with AOM bypassed - wrong
     bits were being changed
 
- central_node_engine-R1-5-0-eic:
+__central_node_engine-R1-5-0-eic__:
   * Change to support AOM enable while mechanical laser shutter
     is closed (works with mps_configuration EIC branch and
     central_node_ioc branches)
 
-central_node_engine-R1-4-1:
+__central_node_engine-R1-4-1__:
   * Change to how the charge integration time is written to FW.
     The value is broken up into bits 0:9 and 16:25.
 
-central_node_engine-R1-4-0:
+__central_node_engine-R1-4-0__:
   * Compatible with mps_database-R1-1-0, which has a change in the
     crates.number to crates.crate_id. This required code changes
     in this library.
 
-central_node_engine-R1-3-3:
+__central_node_engine-R1-3-3__:
   * Implemented bypass for fast digital devices (they must have
     a single device input). The firmware configuration is reloaded
     when a fast digital input bypass is created or expires.
 
-central_node_engine-R1-3-2:
+__central_node_engine-R1-3-2__:
   * Addition of functionality to allow forcing a power class to
     o beam destination (e.g. allow ops to shut off gun by setting
     a PV).
   * Addition of missing firmware call to run central node stand-alone,
     without connecting to central node card.
 
-central_node_engine-R1-3-1:
+__central_node_engine-R1-3-1__:
   * Change introduced in R1-2-5 stops MPS whenever the update thread
     is stopped/started. Modified so it doesn't start MPS only after
     loading a configuration the first time.
 
-central_node_engine-R1-3-0:
+__central_node_engine-R1-3-0__:
   * Addition of Firmware::beamFaultClear(), for clearing
     faults caused by power class or charge violation
 
-central_node_engine-R1-2-5:
+__central_node_engine-R1-2-5__:
   * After config is loaded MPS is not enabled by default, user
     must enable it on the EDM panel
 
-central_node_engine-R1-2-4:
+__central_node_engine-R1-2-4__:
   * Minor fix on the beam charge table readback - changed from 16 to 32 bits
 
-central_node_engine-R1-2-3:
+__central_node_engine-R1-2-3__:
   * Restored loading beam charge table using database values
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,35 +31,35 @@ Release notes for the LCLS-II MPS central node engine.
   * Add name to the `fwPCChangeThread` thread.
   * Fix format on some source files to improve readability.
 
-__central_node_engine-R1-8-0__:
+* __central_node_engine-R1-8-0__:
   * Implement power class change asynchronous notification message
     handler.
   * Fix bugs the HeartBeat class, which was generating long periods
     between heartbeats.
   * Fix bugs and improve the CN engine.
 
-__central_node_engine-R1-7-0__:
+* __central_node_engine-R1-7-0__:
   * Update buildroot to version 2019.08.
   * Update CPSW to version R4.4.1. This implied update boost to version
     1.64.0 and yaml-cpp to version yaml-cpp-0.5.3_boost-1.64.0.
   * Fix all compilation warnings.
   * Merge changes from the EIC branch.
 
-__central_node_engine-R1-6-0-eic__:
+* __central_node_engine-R1-6-0-eic__:
   * Changed logic to allow AOM
   * Bug fixed on the FW configuration with AOM bypassed - wrong
     bits were being changed
 
-__central_node_engine-R1-5-0-eic__:
+* __central_node_engine-R1-5-0-eic__:
   * Change to support AOM enable while mechanical laser shutter
     is closed (works with mps_configuration EIC branch and
     central_node_ioc branches)
 
-__central_node_engine-R1-4-1__:
+* __central_node_engine-R1-4-1__:
   * Change to how the charge integration time is written to FW.
     The value is broken up into bits 0:9 and 16:25.
 
-__central_node_engine-R1-4-0__:
+* __central_node_engine-R1-4-0__:
   * Compatible with mps_database-R1-1-0, which has a change in the
     crates.number to crates.crate_id. This required code changes
     in this library.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -64,33 +64,33 @@ Release notes for the LCLS-II MPS central node engine.
     crates.number to crates.crate_id. This required code changes
     in this library.
 
-__central_node_engine-R1-3-3__:
+* __central_node_engine-R1-3-3__:
   * Implemented bypass for fast digital devices (they must have
     a single device input). The firmware configuration is reloaded
     when a fast digital input bypass is created or expires.
 
-__central_node_engine-R1-3-2__:
+* __central_node_engine-R1-3-2__:
   * Addition of functionality to allow forcing a power class to
     o beam destination (e.g. allow ops to shut off gun by setting
     a PV).
   * Addition of missing firmware call to run central node stand-alone,
     without connecting to central node card.
 
-__central_node_engine-R1-3-1__:
+* __central_node_engine-R1-3-1__:
   * Change introduced in R1-2-5 stops MPS whenever the update thread
     is stopped/started. Modified so it doesn't start MPS only after
     loading a configuration the first time.
 
-__central_node_engine-R1-3-0__:
+* __central_node_engine-R1-3-0__:
   * Addition of Firmware::beamFaultClear(), for clearing
     faults caused by power class or charge violation
 
-__central_node_engine-R1-2-5__:
+* __central_node_engine-R1-2-5__:
   * After config is loaded MPS is not enabled by default, user
     must enable it on the EDM panel
 
-__central_node_engine-R1-2-4__:
+* __central_node_engine-R1-2-4__:
   * Minor fix on the beam charge table readback - changed from 16 to 32 bits
 
-__central_node_engine-R1-2-3__:
+* __central_node_engine-R1-2-3__:
   * Restored loading beam charge table using database values

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -30,35 +30,36 @@ extern TimeAverage AppCardAnalogUpdateTime;
 std::mutex MpsDb::_mutex;
 bool MpsDb::_initialized = false;
 
-MpsDb::MpsDb(uint32_t inputUpdateTimeout) :
-  fwUpdateBuffer( fwUpdateBuferSize ),
-  run( true ),
-  fwUpdateThread( std::thread( &MpsDb::fwUpdateReader, this ) ),
-  fwPCChangeThread( std::thread( &MpsDb::fwPCChangeReader, this ) ),
-  updateInputThread( std::thread( &MpsDb::updateInputs, this ) ),
-  mitigationThread( std::thread( &MpsDb::mitigationWriter, this ) ),
-  inputsUpdated(false),
-  _fastUpdateTimeStamp(0),
-  _diff(0),
-  _maxDiff(0),
-  _diffCount(0),
-  softwareMitigationBuffer(NUM_DESTINATIONS / 8),
-  _inputUpdateTime("Input update time", 360),
-  _clearUpdateTime(false),
-  fwUpdateTimer("FW Update Period", 360),
-  _inputUpdateTimeout(inputUpdateTimeout),
-  _updateCounter(0),
-  _updateTimeoutCounter(0),
-  _pcChangeCounter(0),
-  _pcChangeBadSizeCounter(0),
-  _pcChangeOutOrderCounter(0),
-  _pcChangeLossCounter(0),
-  _pcChangeSameTagCounter(0),
-  _pcChangeFirstPacket(true),
-  _pcChangeDebug(false),
-  _pcFlagsCounters(Firmware::PcChangePacketFlagsLabels.size(), 0),
-  mitigationTxTime( "Mitigation Transmission time", 360 )
-  {
+MpsDb::MpsDb(uint32_t inputUpdateTimeout)
+:
+    fwUpdateBuffer( fwUpdateBuferSize ),
+    run( true ),
+    fwUpdateThread( std::thread( &MpsDb::fwUpdateReader, this ) ),
+    fwPCChangeThread( std::thread( &MpsDb::fwPCChangeReader, this ) ),
+    updateInputThread( std::thread( &MpsDb::updateInputs, this ) ),
+    mitigationThread( std::thread( &MpsDb::mitigationWriter, this ) ),
+    inputsUpdated(false),
+    _fastUpdateTimeStamp(0),
+    _diff(0),
+    _maxDiff(0),
+    _diffCount(0),
+    softwareMitigationBuffer(NUM_DESTINATIONS / 8),
+    _inputUpdateTime("Input update time", 360),
+    _clearUpdateTime(false),
+    fwUpdateTimer("FW Update Period", 360),
+    _inputUpdateTimeout(inputUpdateTimeout),
+    _updateCounter(0),
+    _updateTimeoutCounter(0),
+    _pcChangeCounter(0),
+    _pcChangeBadSizeCounter(0),
+    _pcChangeOutOrderCounter(0),
+    _pcChangeLossCounter(0),
+    _pcChangeSameTagCounter(0),
+    _pcChangeFirstPacket(true),
+    _pcChangeDebug(false),
+    _pcFlagsCounters(Firmware::PcChangePacketFlagsLabels.size(), 0),
+    mitigationTxTime( "Mitigation Transmission time", 360 )
+{
 #if defined(LOG_ENABLED) && !defined(LOG_STDOUT)
   databaseLogger = Loggers::getLogger("DATABASE");
 #endif
@@ -124,634 +125,734 @@ void MpsDb::unlatchAll() {
  * This method reads input states from the central node firmware
  * and updates the status of all digital/analog inputs.
  */
-void MpsDb::updateInputs() {
+void MpsDb::updateInputs()
+{
 
-  std::cout << "Update input thread started" << std::endl;
+    std::cout << "Update input thread started" << std::endl;
 
-  for(;;)
-  {
+    for(;;)
     {
-        std::unique_lock<std::mutex> lock(*(fwUpdateBuffer.getMutex()));
-        while(!fwUpdateBuffer.isReadReady())
         {
-            fwUpdateBuffer.getCondVar()->wait_for( lock, std::chrono::milliseconds(5) );
-            if(!run)
+            std::unique_lock<std::mutex> lock(*(fwUpdateBuffer.getMutex()));
+            while(!fwUpdateBuffer.isReadReady())
             {
-                std::cout << "FW Update Data reader interrupted" << std::endl;
-    return;
+                fwUpdateBuffer.getCondVar()->wait_for( lock, std::chrono::milliseconds(5) );
+                if(!run)
+                {
+                    std::cout << "FW Update Data reader interrupted" << std::endl;
+                    return;
+                }
+            }
+        }
+
+        uint64_t t;
+        memcpy(&t, &fwUpdateBuffer.getReadPtr()->at(8), sizeof(t));
+        uint64_t diff = t - _fastUpdateTimeStamp;
+        _fastUpdateTimeStamp = t;
+
+        if (diff > _maxDiff)
+            _maxDiff = diff;
+
+
+        if (diff > 12000000)
+            _diffCount++;
+
+        _diff = diff;
+
+        Engine::getInstance()._evaluationCycleTime.start(); // Start timer to measure whole eval cycle
+
+        if (_clearUpdateTime)
+        {
+            DeviceInputUpdateTime.clear();
+            AnalogDeviceUpdateTime.clear();
+            AppCardDigitalUpdateTime.clear();
+            AppCardAnalogUpdateTime.clear();
+            _clearUpdateTime = false;
+            _inputUpdateTime.clear();
+            fwUpdateTimer.clear();
+            mitigationTxTime.clear();
+        }
+
+        _inputUpdateTime.start();
+
+        DbApplicationCardMap::iterator applicationCardIt;
+        for (applicationCardIt = applicationCards->begin();
+            applicationCardIt != applicationCards->end();
+            ++applicationCardIt)
+        {
+            (*applicationCardIt).second->updateInputs();
+        }
+
+        fwUpdateBuffer.doneReading();
+
+        _updateCounter++;
+        _inputUpdateTime.tick();
+
+        {
+            std::lock_guard<std::mutex> lock(inputsUpdatedMutex);
+            inputsUpdated = true;
+            inputsUpdatedCondVar.notify_all();
+        }
+    }
+}
+
+void MpsDb::configureAllowedClasses()
+{
+    LOG_TRACE("DATABASE", "Configure: AllowedClasses");
+    std::stringstream errorStream;
+    uint32_t lowestBeamClassNumber = 100;
+    for (DbBeamClassMap::iterator it = beamClasses->begin();
+        it != beamClasses->end();
+        ++it)
+    {
+        if ((*it).second->number < lowestBeamClassNumber)
+        {
+            lowestBeamClassNumber = (*it).second->number;
+            lowestBeamClass = (*it).second;
+        }
+    }
+
+    // Assign BeamClass and BeamDestination to AllowedClass
+    for (DbAllowedClassMap::iterator it = allowedClasses->begin();
+        it != allowedClasses->end();
+        ++it)
+    {
+        int id = (*it).second->beamClassId;
+        DbBeamClassMap::iterator beamIt = beamClasses->find(id);
+        if (beamIt == beamClasses->end())
+        {
+            errorStream <<  "ERROR: Failed to configure database, invalid ID found for BeamClass ("
+                << id << ") for AllowedClass (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+        (*it).second->beamClass = (*beamIt).second;
+
+        id = (*it).second->beamDestinationId;
+        DbBeamDestinationMap::iterator beamDestIt = beamDestinations->find(id);
+        if (beamDestIt == beamDestinations->end())
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found for BeamDestinations ("
+                << id << ") for AllowedClass (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+        (*it).second->beamDestination = (*beamDestIt).second;
+    }
+
+    // Assign AllowedClasses to FaultState or ThresholdFaultState
+    // There are multiple AllowedClasses for each Fault, one per BeamDestination
+    for (DbAllowedClassMap::iterator it = allowedClasses->begin();
+        it != allowedClasses->end();
+        ++it)
+    {
+        int id = (*it).second->faultStateId;
+
+        DbFaultStateMap::iterator digFaultIt = faultStates->find(id);
+        if (digFaultIt != faultStates->end())
+        {
+            // Create a map to hold deviceInput for the digitalDevice
+            if (!(*digFaultIt).second->allowedClasses)
+            {
+                DbAllowedClassMap *faultAllowedClasses = new DbAllowedClassMap();
+                (*digFaultIt).second->allowedClasses = DbAllowedClassMapPtr(faultAllowedClasses);
+            }
+            (*digFaultIt).second->allowedClasses->insert(std::pair<int, DbAllowedClassPtr>((*it).second->id,
+                (*it).second));
+        }
+    }
+}
+
+void MpsDb::configureDeviceTypes()
+{
+    // Compile a list of DeviceStates and assign to the proper DeviceType
+    for (DbDeviceStateMap::iterator it = deviceStates->begin();
+        it != deviceStates->end();
+        ++it)
+    {
+        int id = (*it).second->deviceTypeId;
+
+        DbDeviceTypeMap::iterator deviceType = deviceTypes->find(id);
+        if (deviceType != deviceTypes->end())
+        {
+            // Create a map to hold deviceStates for the deviceType
+            if (!(*deviceType).second->deviceStates)
+            {
+                DbDeviceStateMap *deviceStates = new DbDeviceStateMap();
+                (*deviceType).second->deviceStates = DbDeviceStateMapPtr(deviceStates);
+            }
+            (*deviceType).second->deviceStates->insert(std::pair<int, DbDeviceStatePtr>((*it).second->id,
+                (*it).second));
+        }
+    }
+}
+
+void MpsDb::configureDeviceInputs()
+{
+    LOG_TRACE("DATABASE", "Configure: DeviceInputs");
+    std::stringstream errorStream;
+    // Assign DeviceInputs to it's DigitalDevices, and find the Channel
+    // the device is connected to
+    for (DbDeviceInputMap::iterator it = deviceInputs->begin();
+        it != deviceInputs->end();
+        ++it)
+    {
+        int id = (*it).second->digitalDeviceId;
+
+        DbDigitalDeviceMap::iterator deviceIt = digitalDevices->find(id);
+        if (deviceIt == digitalDevices->end())
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found for DigitalDevice ("
+                << id << ") for DeviceInput (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+
+        // Check if digitalDevice is evaluated in firmaware, set deviceInput->fastEvaluation
+        if ((*deviceIt).second->evaluation == FAST_EVALUATION)
+            (*it).second->fastEvaluation = true;
+        else
+            (*it).second->fastEvaluation = false;
+
+        // Create a map to hold deviceInput for the digitalDevice
+        if (!(*deviceIt).second->inputDevices)
+        {
+            DbDeviceInputMap *deviceInputs = new DbDeviceInputMap();
+            (*deviceIt).second->inputDevices = DbDeviceInputMapPtr(deviceInputs);
+        }
+        else
+        {
+            // Extra check to make sure the digitalDevice has only one input, if
+            // it has evaluation set to FAST
+            if ((*deviceIt).second->evaluation == FAST_EVALUATION)
+            {
+                errorStream << "ERROR: Failed to configure database, found DigitalDevice ("
+                    << id << ") set for FAST_EVALUATION with multiple inputs. Must have single input.";
+                throw(DbException(errorStream.str()));
+            }
+        }
+        (*deviceIt).second->inputDevices->insert(std::pair<int, DbDeviceInputPtr>((*it).second->id,
+            (*it).second));
+        LOG_TRACE("DATABASE", "Adding DeviceInput (" << (*it).second->id << ") to "
+            " DigitalDevice (" << (*deviceIt).second->id << ")");
+
+        int channelId = (*it).second->channelId;
+        DbChannelMap::iterator channelIt = digitalChannels->find(channelId);
+        if (channelIt == digitalChannels->end())
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found for Channel ("
+                << channelId << ") for DeviceInput (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+        (*it).second->channel = (*channelIt).second;
+    }
+
+    // Set the DbDeviceType for all DbDigitaDevices
+    for (DbDigitalDeviceMap::iterator it = digitalDevices->begin();
+        it != digitalDevices->end();
+        ++it)
+    {
+        int typeId = (*it).second->deviceTypeId;
+
+        DbDeviceTypeMap::iterator deviceType = deviceTypes->find(typeId);
+        if (deviceType != deviceTypes->end())
+        {
+            (*it).second->deviceType = (*deviceType).second;
+        }
+        else
+        {
+            errorStream << "ERROR: Failed to configure database, invalid deviceTypeId ("
+                << typeId << ") for DigitalDevice (" <<  (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+    }
+}
+
+void MpsDb::configureFaultInputs()
+{
+    LOG_TRACE("DATABASE", "Configure: FaultInputs");
+    std::stringstream errorStream;
+
+    // Assign DigitalDevice to FaultInputs
+    for (DbFaultInputMap::iterator it = faultInputs->begin();
+        it != faultInputs->end();
+        ++it)
+    {
+        int id = (*it).second->deviceId;
+
+        // Find the DbDigitalDevice or DbAnalogDevice referenced by the FaultInput
+        DbDigitalDeviceMap::iterator deviceIt = digitalDevices->find(id);
+        if (deviceIt == digitalDevices->end())
+        {
+            DbAnalogDeviceMap::iterator aDeviceIt = analogDevices->find(id);
+            if (aDeviceIt == analogDevices->end())
+            {
+                errorStream << "ERROR: Failed to find DigitalDevice/AnalogDevice (" << id
+                    << ") for FaultInput (" << (*it).second->id << ")";
+                throw(DbException(errorStream.str()));
+            }
+            // Found the DbAnalogDevice, configure it
+            else
+            {
+                (*it).second->analogDevice = (*aDeviceIt).second;
+
+                if ((*aDeviceIt).second->evaluation == FAST_EVALUATION)
+                {
+                    LOG_TRACE("DATABASE", "AnalogDevice " << (*aDeviceIt).second->name
+                        << ": Fast Evaluation");
+                    DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
+                    if (faultIt == faults->end())
+                    {
+                        errorStream << "ERROR: Failed to find Fault (" << id
+                            << ") for FaultInput (" << (*it).second->id << ")";
+                        throw(DbException(errorStream.str()));
+                    }
+                    else
+                    {
+                        if (!(*faultIt).second->faultStates)
+                        {
+                            errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
+                                << ") for FaultInput (" << (*it).second->id << ")";
+                            throw(DbException(errorStream.str()));
+                        }
+
+                        // There is one DbFaultState per threshold bit, for BPMs there are
+                        // 24 bits (8 for X, 8 for Y and 8 for TMIT). Other analog devices
+                        // have up to 32 bits (4 integrators) - there is one destination mask
+                        // per integrator
+
+                        // There is a unique power class for each threshold bit (each DbFaultState)
+                        // The destination masks for the thresholds for the same integrator
+                        // must be and'ed together.
+
+                        // Go through the DbFaultStates for this DbFault, i.e. the individual threshold bits
+                        for (DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
+                            faultState != (*faultIt).second->faultStates->end();
+                            ++faultState)
+                        {
+                            // The DbDeviceState value defines which integrator the fault belongs to.
+                            // Bits 0 through 7 are for the first integrator, 8 through 15 for the second,
+                            // and so on.
+                            uint32_t value = (*faultState).second->deviceState->value;
+                            int integratorIndex = 4;
+
+                            if (value & 0x000000FF) integratorIndex = 0;
+                            if (value & 0x0000FF00) integratorIndex = 1;
+                            if (value & 0x00FF0000) integratorIndex = 2;
+                            if (value & 0xFF000000) integratorIndex = 3;
+
+                            if (integratorIndex >= 4)
+                            {
+                                errorStream << "ERROR: Invalid deviceState value Fault (" << (*faultIt).second->id
+                                    << "), FaultInput (" << (*it).second->id << "), DeviceState ("
+                                    << (*faultState).second->deviceState->id << "), value=0x"
+                                    << std::hex << (*faultState).second->deviceState->value << std::dec;
+                                throw(DbException(errorStream.str()));
+                            }
+
+                            uint32_t thresholdIndex = 0;
+                            bool isSet = false;
+                            while (!isSet)
+                            {
+                                if (value & 0x01)
+                                {
+                                    isSet = true;
+                                }
+                                else
+                                {
+                                    thresholdIndex++;
+                                    value >>= 1;
+                                }
+
+                                if (thresholdIndex >= sizeof(uint32_t) * 8)
+                                {
+                                    errorStream << "ERROR: Invalid threshold bit for Fault (" << (*faultIt).second->id
+                                        << "), FaultInput (" << (*it).second->id << "), DeviceState ("
+                                        << (*faultState).second->deviceState->id << ")";
+                                    throw(DbException(errorStream.str()));
+                                }
+                            }
+
+                            // Find the power classes for analog thresholds based on the AllowedClasses.
+                            // Note: even though the database allows for different power classes for
+                            // different destinations for the same fault, the firmware only has a single
+                            // power class to apply for a 16-bit destination mask. For example:
+                            // IM01B Charge Fault has one AllowedClass per destination, where
+                            //   Shutter = power class 1 (destination 1)
+                            //   AOM = power class 0 (destination 2)
+                            // The power class for the destination mask 0x03 is power class 0 (the lowest)
+                            for (DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
+                                allowedClass != (*faultState).second->allowedClasses->end();
+                                ++allowedClass)
+                            {
+                                (*aDeviceIt).second->fastDestinationMask[integratorIndex] |=
+                                    (*allowedClass).second->beamDestination->destinationMask;
+                                LOG_TRACE("DATABASE", "PowerClass: integrator=" << integratorIndex
+                                    << " threshold index=" << thresholdIndex
+                                    << " current power=" << (*aDeviceIt).second->fastPowerClass[thresholdIndex]
+                                    << " power=" << (*allowedClass).second->beamClass->number
+                                    << " allowedClassId=" << (*allowedClass).second->id
+                                    << " destinationMask=0x" << std::hex << (*allowedClass).second->beamDestination->destinationMask << std::dec );
+
+                                if ((*aDeviceIt).second->fastPowerClassInit[thresholdIndex] == 1)
+                                {
+                                    (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
+                                    (*allowedClass).second->beamClass->number;
+                                    (*aDeviceIt).second->fastPowerClassInit[thresholdIndex] = 0;
+                                }
+                                else
+                                {
+                                    if ((*allowedClass).second->beamClass->number <
+                                        (*aDeviceIt).second->fastPowerClass[thresholdIndex])
+                                    {
+                                        (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
+                                        (*allowedClass).second->beamClass->number;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            (*it).second->digitalDevice = (*deviceIt).second;
+            // If the DbDigitalDevice is set for fast evaluation, save a pointer to the
+            // DbFaultInput
+            if ((*deviceIt).second->evaluation == FAST_EVALUATION)
+            {
+                DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
+                if (faultIt == faults->end())
+                {
+                    errorStream << "ERROR: Failed to find Fault (" << id
+                        << ") for FaultInput (" << (*it).second->id << ")";
+                    throw(DbException(errorStream.str()));
+                }
+                else
+                {
+                    if (!(*faultIt).second->faultStates)
+                    {
+                        errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
+                            << ") for FaultInput (" << (*it).second->id << ")";
+                        throw(DbException(errorStream.str()));
+                    }
+                    (*deviceIt).second->fastDestinationMask = 0;
+                    (*deviceIt).second->fastPowerClass = 100;
+                    (*deviceIt).second->fastExpectedState = 0;
+
+                    if ((*faultIt).second->faultStates->size() != 1)
+                    {
+                        errorStream << "ERROR: DigitalDevice configured with FAST evaluation must have one fault state only."
+                            << " Found " << (*faultIt).second->faultStates->size() << " fault states for "
+                            << "device " << (*deviceIt).second->name;
+                        throw(DbException(errorStream.str()));
+                    }
+                    DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
+
+                    // Set the expected state as the oposite of the expected faulted value
+                    // For example a faulted fast valve sets the digital input to high (0V, digital 0),
+                    // the expected normal state is 1.
+                    if (!(*faultState).second->deviceState->value)
+                      (*deviceIt).second->fastExpectedState = 1;
+
+                    //    DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
+                    for (DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
+                        allowedClass != (*faultState).second->allowedClasses->end();
+                        ++allowedClass)
+                    {
+                        (*deviceIt).second->fastDestinationMask |= (*allowedClass).second->beamDestination->destinationMask;
+                        if ((*allowedClass).second->beamClass->number < (*deviceIt).second->fastPowerClass)
+                            (*deviceIt).second->fastPowerClass = (*allowedClass).second->beamClass->number;
+
+                    }
+                }
+            }
+        }
+    }
+    //  std::cout << "assigning fault inputs to faults" << std::endl;
+
+    // Assing fault inputs to faults
+    for (DbFaultInputMap::iterator it = faultInputs->begin();
+        it != faultInputs->end();
+        ++it)
+    {
+        int id = (*it).second->faultId;
+
+        DbFaultMap::iterator faultIt = faults->find(id);
+        if (faultIt == faults->end())
+        {
+            errorStream <<  "ERROR: Failed to configure database, invalid ID found for Fault ("
+                << id << ") for FaultInput (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+
+        // Create a map to hold faultInputs for the fault
+        if (!(*faultIt).second->faultInputs)
+        {
+            DbFaultInputMap *faultInputs = new DbFaultInputMap();
+            (*faultIt).second->faultInputs = DbFaultInputMapPtr(faultInputs);
+        }
+        (*faultIt).second->faultInputs->insert(std::pair<int, DbFaultInputPtr>((*it).second->id,
+            (*it).second));
+    }
+
+    //  std::cout << "assign evaluation" << std::endl;
+
+    // Assign an evaluation to a Fault based on the inputs to its FaultInputs
+    // Faults whose inputs are all evaluated in firmware should be only handled
+    // by the firmware.
+    // TODO: set DbFault.evaluation
+    for (DbFaultMap::iterator faultIt = faults->begin(); faultIt != faults->end(); ++faultIt)
+    {
+        bool slowEvaluation = false;
+        if (!(*faultIt).second->faultInputs)
+        {
+            errorStream << "ERROR: Missing faultInputs map for Fault \""
+                << (*faultIt).second->name << "\": "
+                << (*faultIt).second->description;
+            throw(DbException(errorStream.str()));
+        }
+
+        for (DbFaultInputMap::iterator inputIt = (*faultIt).second->faultInputs->begin();
+            inputIt != (*faultIt).second->faultInputs->end();
+            ++inputIt)
+        {
+            if ((*inputIt).second->analogDevice)
+            {
+                if ((*inputIt).second->analogDevice->evaluation == SLOW_EVALUATION)
+                    slowEvaluation = true;
+            }
+            else if ((*inputIt).second->digitalDevice)
+            {
+                if ((*inputIt).second->digitalDevice->evaluation == SLOW_EVALUATION)
+                    slowEvaluation = true;
+            }
+        }
+
+        if (slowEvaluation)
+            (*faultIt).second->evaluation = SLOW_EVALUATION;
+        else
+            (*faultIt).second->evaluation = FAST_EVALUATION;
+    }
+    //  std::cout << "done with faultInputs" << std::endl;
+}
+
+void MpsDb::configureFaultStates()
+{
+    LOG_TRACE("DATABASE", "Configure: FaultStates");
+    std::stringstream errorStream;
+    // Assign all FaultStates to a Fault, and also
+    // find the DeviceState and save a reference in the FaultState
+    for (DbFaultStateMap::iterator it = faultStates->begin();
+        it != faultStates->end();
+        ++it)
+    {
+        int id = (*it).second->faultId;
+
+        DbFaultMap::iterator faultIt = faults->find(id);
+        if (faultIt == faults->end())
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found for Fault ("
+                << id << ") for FaultState (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+
+        // Create a map to hold faultInputs for the fault
+        if (!(*faultIt).second->faultStates)
+        {
+            DbFaultStateMap *digFaultStates = new DbFaultStateMap();
+            (*faultIt).second->faultStates = DbFaultStateMapPtr(digFaultStates);
+        }
+        (*faultIt).second->faultStates->insert(std::pair<int, DbFaultStatePtr>((*it).second->id,
+            (*it).second));
+        LOG_TRACE("DATABASE", "Adding FaultState (" << (*it).second->id << ") to "
+            " Fault (" << (*faultIt).second->id << ", " << (*faultIt).second->name
+            << ", " << (*faultIt).second->description << ")");
+
+        // If this DigitalFault is the default, then assign it to the fault:
+        if ((*it).second->defaultState && !((*faultIt).second->defaultFaultState))
+            (*faultIt).second->defaultFaultState = (*it).second;
+
+        // DeviceState
+        id = (*it).second->deviceStateId;
+        DbDeviceStateMap::iterator deviceStateIt = deviceStates->find(id);
+        if (deviceStateIt == deviceStates->end())
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found for DeviceState ("
+                << id << ") for FaultState (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+        (*it).second->deviceState = (*deviceStateIt).second;
+    }
+
+    // After assigning all FaultStates to Faults, check if all Faults
+    // do have FaultStates
+    for (DbFaultMap::iterator fault = faults->begin();
+        fault != faults->end();
+        ++fault)
+    {
+        if (!(*fault).second->faultStates)
+        {
+            errorStream << "ERROR: Fault " << (*fault).second->name << " ("
+                << (*fault).second->description << ", id="
+                << (*fault).second->id << ") has no FaultStates";
+            throw(DbException(errorStream.str()));
+        }
+    }
+}
+
+void MpsDb::configureAnalogDevices()
+{
+    LOG_TRACE("DATABASE", "Configure: AnalogDevices");
+    std::stringstream errorStream;
+    // Assign the AnalogDeviceType to each AnalogDevice
+    for (DbAnalogDeviceMap::iterator it = analogDevices->begin();
+        it != analogDevices->end();
+        ++it)
+    {
+        int typeId = (*it).second->deviceTypeId;
+
+        DbDeviceTypeMap::iterator deviceType = deviceTypes->find(typeId);
+        if (deviceType != deviceTypes->end())
+        {
+            (*it).second->deviceType = (*deviceType).second;
+        }
+        else
+        {
+            errorStream << "ERROR: Failed to configure database, invalid deviceTypeId ("
+                << typeId << ") for AnalogDevice (" <<  (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+
+        int channelId = (*it).second->channelId;
+        DbChannelMap::iterator channelIt = analogChannels->find(channelId);
+        if (channelIt == analogChannels->end())
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found for Channel ("
+                << channelId << ") for AnalogDevice (" << (*it).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+        (*it).second->channel = (*channelIt).second;
+    }
+}
+
+void MpsDb::configureIgnoreConditions()
+{
+    LOG_TRACE("DATABASE", "Configure: IgnoreConditions");
+    std::stringstream errorStream;
+
+    // Loop through the IgnoreConditions, and assign to the Condition
+    for (DbIgnoreConditionMap::iterator ignoreCondition = ignoreConditions->begin();
+        ignoreCondition != ignoreConditions->end();
+        ++ignoreCondition)
+    {
+        uint32_t conditionId = (*ignoreCondition).second->conditionId;
+        //    std::cout << "conditionId=" << conditionId << " ";
+
+        DbConditionMap::iterator condition = conditions->find(conditionId);
+        if (condition != conditions->end())
+        {
+            // Create a map to hold IgnoreConditions
+            if (!(*condition).second->ignoreConditions)
+            {
+                DbIgnoreConditionMap *ignoreConditionMap = new DbIgnoreConditionMap();
+                (*condition).second->ignoreConditions = DbIgnoreConditionMapPtr(ignoreConditionMap);
+            }
+            (*condition).second->ignoreConditions->
+            insert(std::pair<int, DbIgnoreConditionPtr>((*ignoreCondition).second->id, (*ignoreCondition).second));
+        }
+        else
+        {
+            errorStream << "ERROR: Failed to configure database, invalid conditionId ("
+                << conditionId << ") for ignoreCondition (" <<  (*ignoreCondition).second->id << ")";
+            throw(DbException(errorStream.str()));
+        }
+
+        // Find if the ignored fault state is digital or analog
+        uint32_t faultStateId = (*ignoreCondition).second->faultStateId;
+        //    std::cout << "faultStateId=" << faultStateId << " ";
+
+        if (faultStateId != DbIgnoreCondition::INVALID_ID)
+        {
+            DbFaultStateMap::iterator faultIt = faultStates->find(faultStateId);
+            if (faultIt != faultStates->end())
+            {
+                (*ignoreCondition).second->faultState = (*faultIt).second;
+            }
+            else
+            {
+                errorStream << "ERROR: Failed to configure database, invalid ID for FaultState ("
+                    << faultStateId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+                throw(DbException(errorStream.str()));
+            }
+        }
+
+        uint32_t analogDeviceId = (*ignoreCondition).second->analogDeviceId;
+        //    std::cout << "analogDeviceId=" << analogDeviceId << " ";
+
+        if (analogDeviceId != DbIgnoreCondition::INVALID_ID)
+        {
+            DbAnalogDeviceMap::iterator deviceIt = analogDevices->find(analogDeviceId);
+            if (deviceIt != analogDevices->end())
+            {
+                (*ignoreCondition).second->analogDevice = (*deviceIt).second;
+            }
+            else
+            {
+                errorStream << "ERROR: Failed to configure database, invalid ID for AnalogDevice ("
+                    << analogDeviceId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+                throw(DbException(errorStream.str()));
+            }
+        }
+        else
+        {
+            if (faultStateId == DbIgnoreCondition::INVALID_ID)
+            {
+                errorStream << "ERROR: Failed to configure database, invalid ID for FaultState and"
+                    << " FaultState for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+                throw(DbException(errorStream.str()));
             }
         }
     }
 
-    uint64_t t;
-    memcpy(&t, &fwUpdateBuffer.getReadPtr()->at(8), sizeof(t));
-    uint64_t diff = t - _fastUpdateTimeStamp;
-    _fastUpdateTimeStamp = t;
-
-    if (diff > _maxDiff) {
-      _maxDiff = diff;
-    }
-
-    if (diff > 12000000) {
-      _diffCount++;
-    }
-    _diff = diff;
-
-    Engine::getInstance()._evaluationCycleTime.start(); // Start timer to measure whole eval cycle
-
-    if (_clearUpdateTime) {
-      DeviceInputUpdateTime.clear();
-      AnalogDeviceUpdateTime.clear();
-      AppCardDigitalUpdateTime.clear();
-      AppCardAnalogUpdateTime.clear();
-      _clearUpdateTime = false;
-      _inputUpdateTime.clear();
-      fwUpdateTimer.clear();
-      mitigationTxTime.clear();
-    }
-
-    _inputUpdateTime.start();
-
-    DbApplicationCardMap::iterator applicationCardIt;
-    for (applicationCardIt = applicationCards->begin();
-       applicationCardIt != applicationCards->end();
-       ++applicationCardIt) {
-      (*applicationCardIt).second->updateInputs();
-    }
-
-
-    fwUpdateBuffer.doneReading();
-
-    _updateCounter++;
-    _inputUpdateTime.tick();
-
+    // Loop through the ConditionInputs, and assign to the Condition
+    for (DbConditionInputMap::iterator conditionInput = conditionInputs->begin();
+        conditionInput != conditionInputs->end();
+        ++conditionInput)
     {
-      std::lock_guard<std::mutex> lock(inputsUpdatedMutex);
-      inputsUpdated = true;
-      inputsUpdatedCondVar.notify_all();
-    }
-  }
-}
+        uint32_t conditionId = (*conditionInput).second->conditionId;
 
-void MpsDb::configureAllowedClasses() {
-  LOG_TRACE("DATABASE", "Configure: AllowedClasses");
-  std::stringstream errorStream;
-  uint32_t lowestBeamClassNumber = 100;
-  for (DbBeamClassMap::iterator it = beamClasses->begin();
-       it != beamClasses->end(); ++it) {
-    if ((*it).second->number < lowestBeamClassNumber) {
-      lowestBeamClassNumber = (*it).second->number;
-      lowestBeamClass = (*it).second;
-    }
-  }
-
-  // Assign BeamClass and BeamDestination to AllowedClass
-  for (DbAllowedClassMap::iterator it = allowedClasses->begin();
-       it != allowedClasses->end(); ++it) {
-    int id = (*it).second->beamClassId;
-    DbBeamClassMap::iterator beamIt = beamClasses->find(id);
-    if (beamIt == beamClasses->end()) {
-      errorStream <<  "ERROR: Failed to configure database, invalid ID found for BeamClass ("
-      << id << ") for AllowedClass (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    (*it).second->beamClass = (*beamIt).second;
-
-    id = (*it).second->beamDestinationId;
-    DbBeamDestinationMap::iterator beamDestIt = beamDestinations->find(id);
-    if (beamDestIt == beamDestinations->end()) {
-      errorStream << "ERROR: Failed to configure database, invalid ID found for BeamDestinations ("
-      << id << ") for AllowedClass (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    (*it).second->beamDestination = (*beamDestIt).second;
-  }
-
-  // Assign AllowedClasses to FaultState or ThresholdFaultState
-  // There are multiple AllowedClasses for each Fault, one per BeamDestination
-  for (DbAllowedClassMap::iterator it = allowedClasses->begin();
-       it != allowedClasses->end(); ++it) {
-    int id = (*it).second->faultStateId;
-
-    DbFaultStateMap::iterator digFaultIt = faultStates->find(id);
-    if (digFaultIt != faultStates->end()) {
-      // Create a map to hold deviceInput for the digitalDevice
-      if (!(*digFaultIt).second->allowedClasses) {
-  DbAllowedClassMap *faultAllowedClasses = new DbAllowedClassMap();
-  (*digFaultIt).second->allowedClasses = DbAllowedClassMapPtr(faultAllowedClasses);
-      }
-      (*digFaultIt).second->allowedClasses->insert(std::pair<int, DbAllowedClassPtr>((*it).second->id,
-                         (*it).second));
-    }
-  }
-}
-
-void MpsDb::configureDeviceTypes() {
-  // Compile a list of DeviceStates and assign to the proper DeviceType
-  for (DbDeviceStateMap::iterator it = deviceStates->begin();
-       it != deviceStates->end(); ++it) {
-    int id = (*it).second->deviceTypeId;
-
-    DbDeviceTypeMap::iterator deviceType = deviceTypes->find(id);
-    if (deviceType != deviceTypes->end()) {
-      // Create a map to hold deviceStates for the deviceType
-      if (!(*deviceType).second->deviceStates) {
-  DbDeviceStateMap *deviceStates = new DbDeviceStateMap();
-  (*deviceType).second->deviceStates = DbDeviceStateMapPtr(deviceStates);
-      }
-      (*deviceType).second->deviceStates->insert(std::pair<int, DbDeviceStatePtr>((*it).second->id,
-                      (*it).second));
-    }
-  }
-}
-
-void MpsDb::configureDeviceInputs() {
-  LOG_TRACE("DATABASE", "Configure: DeviceInputs");
-  std::stringstream errorStream;
-  // Assign DeviceInputs to it's DigitalDevices, and find the Channel
-  // the device is connected to
-  for (DbDeviceInputMap::iterator it = deviceInputs->begin();
-       it != deviceInputs->end(); ++it) {
-    int id = (*it).second->digitalDeviceId;
-
-    DbDigitalDeviceMap::iterator deviceIt = digitalDevices->find(id);
-    if (deviceIt == digitalDevices->end()) {
-      errorStream << "ERROR: Failed to configure database, invalid ID found for DigitalDevice ("
-      << id << ") for DeviceInput (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-
-    // Check if digitalDevice is evaluated in firmaware, set deviceInput->fastEvaluation
-    if ((*deviceIt).second->evaluation == FAST_EVALUATION) {
-      (*it).second->fastEvaluation = true;
-    }
-    else {
-      (*it).second->fastEvaluation = false;
-    }
-
-    // Create a map to hold deviceInput for the digitalDevice
-    if (!(*deviceIt).second->inputDevices) {
-      DbDeviceInputMap *deviceInputs = new DbDeviceInputMap();
-      (*deviceIt).second->inputDevices = DbDeviceInputMapPtr(deviceInputs);
-    }
-    else {
-      // Extra check to make sure the digitalDevice has only one input, if
-      // it has evaluation set to FAST
-      if ((*deviceIt).second->evaluation == FAST_EVALUATION) {
-  errorStream << "ERROR: Failed to configure database, found DigitalDevice ("
-        << id << ") set for FAST_EVALUATION with multiple inputs. Must have single input.";
-  throw(DbException(errorStream.str()));
-      }
-    }
-    (*deviceIt).second->inputDevices->insert(std::pair<int, DbDeviceInputPtr>((*it).second->id,
-                        (*it).second));
-    LOG_TRACE("DATABASE", "Adding DeviceInput (" << (*it).second->id << ") to "
-        " DigitalDevice (" << (*deviceIt).second->id << ")");
-
-    int channelId = (*it).second->channelId;
-    DbChannelMap::iterator channelIt = digitalChannels->find(channelId);
-    if (channelIt == digitalChannels->end()) {
-      errorStream << "ERROR: Failed to configure database, invalid ID found for Channel ("
-      << channelId << ") for DeviceInput (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    (*it).second->channel = (*channelIt).second;
-  }
-
-  // Set the DbDeviceType for all DbDigitaDevices
-  for (DbDigitalDeviceMap::iterator it = digitalDevices->begin();
-       it != digitalDevices->end(); ++it) {
-    int typeId = (*it).second->deviceTypeId;
-
-    DbDeviceTypeMap::iterator deviceType = deviceTypes->find(typeId);
-    if (deviceType != deviceTypes->end()) {
-      (*it).second->deviceType = (*deviceType).second;
-    }
-    else {
-      errorStream << "ERROR: Failed to configure database, invalid deviceTypeId ("
-      << typeId << ") for DigitalDevice (" <<  (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-  }
-
-}
-
-void MpsDb::configureFaultInputs() {
-  LOG_TRACE("DATABASE", "Configure: FaultInputs");
-  std::stringstream errorStream;
-
-  // Assign DigitalDevice to FaultInputs
-  for (DbFaultInputMap::iterator it = faultInputs->begin();
-       it != faultInputs->end(); ++it) {
-    int id = (*it).second->deviceId;
-
-    // Find the DbDigitalDevice or DbAnalogDevice referenced by the FaultInput
-    DbDigitalDeviceMap::iterator deviceIt = digitalDevices->find(id);
-    if (deviceIt == digitalDevices->end()) {
-      DbAnalogDeviceMap::iterator aDeviceIt = analogDevices->find(id);
-      if (aDeviceIt == analogDevices->end()) {
-  errorStream << "ERROR: Failed to find DigitalDevice/AnalogDevice (" << id
-        << ") for FaultInput (" << (*it).second->id << ")";
-  throw(DbException(errorStream.str()));
-      }
-      // Found the DbAnalogDevice, configure it
-      else {
-  (*it).second->analogDevice = (*aDeviceIt).second;
-
-  if ((*aDeviceIt).second->evaluation == FAST_EVALUATION) {
-    LOG_TRACE("DATABASE", "AnalogDevice " << (*aDeviceIt).second->name
-        << ": Fast Evaluation");
-    DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
-    if (faultIt == faults->end()) {
-      errorStream << "ERROR: Failed to find Fault (" << id
-      << ") for FaultInput (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    else {
-      if (!(*faultIt).second->faultStates) {
-        errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
-        << ") for FaultInput (" << (*it).second->id << ")";
-        throw(DbException(errorStream.str()));
-      }
-
-      // There is one DbFaultState per threshold bit, for BPMs there are
-      // 24 bits (8 for X, 8 for Y and 8 for TMIT). Other analog devices
-      // have up to 32 bits (4 integrators) - there is one destination mask
-      // per integrator
-
-      // There is a unique power class for each threshold bit (each DbFaultState)
-      // The destination masks for the thresholds for the same integrator
-      // must be and'ed together.
-
-      // Go through the DbFaultStates for this DbFault, i.e. the individual threshold bits
-      for (DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
-     faultState != (*faultIt).second->faultStates->end(); ++faultState) {
-        // The DbDeviceState value defines which integrator the fault belongs to.
-        // Bits 0 through 7 are for the first integrator, 8 through 15 for the second,
-        // and so on.
-        uint32_t value = (*faultState).second->deviceState->value;
-        int integratorIndex = 4;
-
-        if (value & 0x000000FF) integratorIndex = 0;
-        if (value & 0x0000FF00) integratorIndex = 1;
-        if (value & 0x00FF0000) integratorIndex = 2;
-        if (value & 0xFF000000) integratorIndex = 3;
-
-        if (integratorIndex >= 4) {
-    errorStream << "ERROR: Invalid deviceState value Fault (" << (*faultIt).second->id
-          << "), FaultInput (" << (*it).second->id << "), DeviceState ("
-          << (*faultState).second->deviceState->id << "), value=0x"
-          << std::hex << (*faultState).second->deviceState->value << std::dec;
-    throw(DbException(errorStream.str()));
+        DbConditionMap::iterator condition = conditions->find(conditionId);
+        if (condition != conditions->end())
+        {
+            // Create a map to hold ConditionInputs
+            if (!(*condition).second->conditionInputs)
+            {
+                DbConditionInputMap *conditionInputMap = new DbConditionInputMap();
+                (*condition).second->conditionInputs = DbConditionInputMapPtr(conditionInputMap);
+            }
+            (*condition).second->conditionInputs->
+            insert(std::pair<int, DbConditionInputPtr>((*conditionInput).second->id, (*conditionInput).second));
+        }
+        else
+        {
+            errorStream << "ERROR: Failed to configure database, invalid conditionId ("
+                << conditionId << ") for conditionInput (" <<  (*conditionInput).second->id << ")";
+            throw(DbException(errorStream.str()));
         }
 
-        uint32_t thresholdIndex = 0;
-        bool isSet = false;
-        while (!isSet) {
-    if (value & 0x01) {
-      isSet = true;
-    }
-    else {
-      thresholdIndex++;
-      value >>= 1;
-    }
-    if (thresholdIndex >= sizeof(uint32_t) * 8) {
-      errorStream << "ERROR: Invalid threshold bit for Fault (" << (*faultIt).second->id
-            << "), FaultInput (" << (*it).second->id << "), DeviceState ("
-            << (*faultState).second->deviceState->id << ")";
-      throw(DbException(errorStream.str()));
-    }
+        uint32_t faultStateId = (*conditionInput).second->faultStateId;
+
+        DbFaultStateMap::iterator faultIt = faultStates->find(faultStateId);
+        if (faultIt != faultStates->end())
+        {
+            (*conditionInput).second->faultState = (*faultIt).second;
         }
-
-        // Find the power classes for analog thresholds based on the AllowedClasses.
-        // Note: even though the database allows for different power classes for
-        // different destinations for the same fault, the firmware only has a single
-        // power class to apply for a 16-bit destination mask. For example:
-        // IM01B Charge Fault has one AllowedClass per destination, where
-        //   Shutter = power class 1 (destination 1)
-        //   AOM = power class 0 (destination 2)
-        // The power class for the destination mask 0x03 is power class 0 (the lowest)
-        for (DbAllowedClassMap::iterator allowedClass =
-         (*faultState).second->allowedClasses->begin();
-       allowedClass != (*faultState).second->allowedClasses->end(); ++allowedClass) {
-    (*aDeviceIt).second->fastDestinationMask[integratorIndex] |=
-      (*allowedClass).second->beamDestination->destinationMask;
-    LOG_TRACE("DATABASE", "PowerClass: integrator=" << integratorIndex
-        << " threshold index=" << thresholdIndex
-        << " current power=" << (*aDeviceIt).second->fastPowerClass[thresholdIndex]
-        << " power=" << (*allowedClass).second->beamClass->number
-        << " allowedClassId=" << (*allowedClass).second->id
-        << " destinationMask=0x" << std::hex << (*allowedClass).second->beamDestination->destinationMask << std::dec );
-    if ((*aDeviceIt).second->fastPowerClassInit[thresholdIndex] == 1) {
-      (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
-        (*allowedClass).second->beamClass->number;
-      (*aDeviceIt).second->fastPowerClassInit[thresholdIndex] = 0;
-    }
-    else {
-      if ((*allowedClass).second->beamClass->number <
-          (*aDeviceIt).second->fastPowerClass[thresholdIndex]) {
-        (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
-          (*allowedClass).second->beamClass->number;
-      }
-    }
+        else
+        {
+            errorStream << "ERROR: Failed to configure database, invalid ID found of FaultState ("
+                << faultStateId << ") for ConditionInput (" <<  (*conditionInput).second->id << ")";
+            throw(DbException(errorStream.str()));
         }
-      }
     }
-  }
-      }
-    }
-    else {
-      (*it).second->digitalDevice = (*deviceIt).second;
-      // If the DbDigitalDevice is set for fast evaluation, save a pointer to the
-      // DbFaultInput
-      if ((*deviceIt).second->evaluation == FAST_EVALUATION) {
-  DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
-  if (faultIt == faults->end()) {
-    errorStream << "ERROR: Failed to find Fault (" << id
-          << ") for FaultInput (" << (*it).second->id << ")";
-    throw(DbException(errorStream.str()));
-  }
-  else {
-    if (!(*faultIt).second->faultStates) {
-      errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
-      << ") for FaultInput (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    (*deviceIt).second->fastDestinationMask = 0;
-    (*deviceIt).second->fastPowerClass = 100;
-    (*deviceIt).second->fastExpectedState = 0;
-
-    if ((*faultIt).second->faultStates->size() != 1) {
-      errorStream << "ERROR: DigitalDevice configured with FAST evaluation must have one fault state only."
-      << " Found " << (*faultIt).second->faultStates->size() << " fault states for "
-      << "device " << (*deviceIt).second->name;
-      throw(DbException(errorStream.str()));
-    }
-    DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
-
-    // Set the expected state as the oposite of the expected faulted value
-    // For example a faulted fast valve sets the digital input to high (0V, digital 0),
-    // the expected normal state is 1.
-    if (!(*faultState).second->deviceState->value) {
-      (*deviceIt).second->fastExpectedState = 1;
-    }
-
-    //    DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
-    for (DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
-         allowedClass != (*faultState).second->allowedClasses->end(); ++allowedClass) {
-      (*deviceIt).second->fastDestinationMask |= (*allowedClass).second->beamDestination->destinationMask;
-      if ((*allowedClass).second->beamClass->number < (*deviceIt).second->fastPowerClass) {
-        (*deviceIt).second->fastPowerClass = (*allowedClass).second->beamClass->number;
-      }
-    }
-  }
-      }
-    }
-  }
-  //  std::cout << "assigning fault inputs to faults" << std::endl;
-
-  // Assing fault inputs to faults
-  for (DbFaultInputMap::iterator it = faultInputs->begin();
-       it != faultInputs->end(); ++it) {
-    int id = (*it).second->faultId;
-
-    DbFaultMap::iterator faultIt = faults->find(id);
-    if (faultIt == faults->end()) {
-      errorStream <<  "ERROR: Failed to configure database, invalid ID found for Fault ("
-      << id << ") for FaultInput (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-
-    // Create a map to hold faultInputs for the fault
-    if (!(*faultIt).second->faultInputs) {
-      DbFaultInputMap *faultInputs = new DbFaultInputMap();
-      (*faultIt).second->faultInputs = DbFaultInputMapPtr(faultInputs);
-    }
-    (*faultIt).second->faultInputs->insert(std::pair<int, DbFaultInputPtr>((*it).second->id,
-                     (*it).second));
-  }
-
-  //  std::cout << "assign evaluation" << std::endl;
-
-  // Assign an evaluation to a Fault based on the inputs to its FaultInputs
-  // Faults whose inputs are all evaluated in firmware should be only handled
-  // by the firmware.
-  // TODO: set DbFault.evaluation
-  for (DbFaultMap::iterator faultIt = faults->begin(); faultIt != faults->end(); ++faultIt) {
-    bool slowEvaluation = false;
-    if (!(*faultIt).second->faultInputs) {
-      errorStream << "ERROR: Missing faultInputs map for Fault \""
-      << (*faultIt).second->name << "\": "
-      << (*faultIt).second->description;
-      throw(DbException(errorStream.str()));
-    }
-
-    for (DbFaultInputMap::iterator inputIt = (*faultIt).second->faultInputs->begin();
-   inputIt != (*faultIt).second->faultInputs->end(); ++inputIt) {
-      if ((*inputIt).second->analogDevice) {
-  if ((*inputIt).second->analogDevice->evaluation == SLOW_EVALUATION) {
-    slowEvaluation = true;
-  }
-      }
-      else if ((*inputIt).second->digitalDevice) {
-  if ((*inputIt).second->digitalDevice->evaluation == SLOW_EVALUATION) {
-    slowEvaluation = true;
-  }
-      }
-    }
-    if (slowEvaluation) {
-      (*faultIt).second->evaluation = SLOW_EVALUATION;
-    }
-    else {
-      (*faultIt).second->evaluation = FAST_EVALUATION;
-    }
-  }
-  //  std::cout << "done with faultInputs" << std::endl;
-}
-
-void MpsDb::configureFaultStates() {
-  LOG_TRACE("DATABASE", "Configure: FaultStates");
- std::stringstream errorStream;
-  // Assign all FaultStates to a Fault, and also
-  // find the DeviceState and save a reference in the FaultState
-  for (DbFaultStateMap::iterator it = faultStates->begin();
-       it != faultStates->end(); ++it) {
-    int id = (*it).second->faultId;
-
-    DbFaultMap::iterator faultIt = faults->find(id);
-    if (faultIt == faults->end()) {
-      errorStream << "ERROR: Failed to configure database, invalid ID found for Fault ("
-      << id << ") for FaultState (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-
-    // Create a map to hold faultInputs for the fault
-    if (!(*faultIt).second->faultStates) {
-      DbFaultStateMap *digFaultStates = new DbFaultStateMap();
-      (*faultIt).second->faultStates = DbFaultStateMapPtr(digFaultStates);
-    }
-    (*faultIt).second->faultStates->insert(std::pair<int, DbFaultStatePtr>((*it).second->id,
-                       (*it).second));
-    LOG_TRACE("DATABASE", "Adding FaultState (" << (*it).second->id << ") to "
-        " Fault (" << (*faultIt).second->id << ", " << (*faultIt).second->name
-        << ", " << (*faultIt).second->description << ")");
-
-    // If this DigitalFault is the default, then assign it to the fault:
-    if ((*it).second->defaultState && !((*faultIt).second->defaultFaultState)) {
-      (*faultIt).second->defaultFaultState = (*it).second;
-    }
-
-    // DeviceState
-    id = (*it).second->deviceStateId;
-    DbDeviceStateMap::iterator deviceStateIt = deviceStates->find(id);
-    if (deviceStateIt == deviceStates->end()) {
-      errorStream << "ERROR: Failed to configure database, invalid ID found for DeviceState ("
-      << id << ") for FaultState (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    (*it).second->deviceState = (*deviceStateIt).second;
-  }
-
-  // After assigning all FaultStates to Faults, check if all Faults
-  // do have FaultStates
-  for (DbFaultMap::iterator fault = faults->begin();
-       fault != faults->end(); ++fault) {
-    if (!(*fault).second->faultStates) {
-      errorStream << "ERROR: Fault " << (*fault).second->name << " ("
-      << (*fault).second->description << ", id="
-      << (*fault).second->id << ") has no FaultStates";
-      throw(DbException(errorStream.str()));
-    }
-  }
-}
-
-void MpsDb::configureAnalogDevices() {
-  LOG_TRACE("DATABASE", "Configure: AnalogDevices");
-  std::stringstream errorStream;
-  // Assign the AnalogDeviceType to each AnalogDevice
-  for (DbAnalogDeviceMap::iterator it = analogDevices->begin();
-       it != analogDevices->end(); ++it) {
-    int typeId = (*it).second->deviceTypeId;
-
-    DbDeviceTypeMap::iterator deviceType = deviceTypes->find(typeId);
-    if (deviceType != deviceTypes->end()) {
-      (*it).second->deviceType = (*deviceType).second;
-    }
-    else {
-      errorStream << "ERROR: Failed to configure database, invalid deviceTypeId ("
-      << typeId << ") for AnalogDevice (" <<  (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-
-    int channelId = (*it).second->channelId;
-    DbChannelMap::iterator channelIt = analogChannels->find(channelId);
-    if (channelIt == analogChannels->end()) {
-      errorStream << "ERROR: Failed to configure database, invalid ID found for Channel ("
-      << channelId << ") for AnalogDevice (" << (*it).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-    (*it).second->channel = (*channelIt).second;
-  }
-}
-
-void MpsDb::configureIgnoreConditions() {
-  LOG_TRACE("DATABASE", "Configure: IgnoreConditions");
-  std::stringstream errorStream;
-
-  // Loop through the IgnoreConditions, and assign to the Condition
-  for (DbIgnoreConditionMap::iterator ignoreCondition = ignoreConditions->begin();
-       ignoreCondition != ignoreConditions->end(); ++ignoreCondition) {
-    uint32_t conditionId = (*ignoreCondition).second->conditionId;
-    //    std::cout << "conditionId=" << conditionId << " ";
-
-    DbConditionMap::iterator condition = conditions->find(conditionId);
-    if (condition != conditions->end()) {
-      // Create a map to hold IgnoreConditions
-      if (!(*condition).second->ignoreConditions) {
-  DbIgnoreConditionMap *ignoreConditionMap = new DbIgnoreConditionMap();
-  (*condition).second->ignoreConditions = DbIgnoreConditionMapPtr(ignoreConditionMap);
-      }
-      (*condition).second->ignoreConditions->
-  insert(std::pair<int, DbIgnoreConditionPtr>((*ignoreCondition).second->id, (*ignoreCondition).second));
-    }
-    else {
-      errorStream << "ERROR: Failed to configure database, invalid conditionId ("
-      << conditionId << ") for ignoreCondition (" <<  (*ignoreCondition).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-
-    // Find if the ignored fault state is digital or analog
-    uint32_t faultStateId = (*ignoreCondition).second->faultStateId;
-    //    std::cout << "faultStateId=" << faultStateId << " ";
-
-    if (faultStateId != DbIgnoreCondition::INVALID_ID) {
-      DbFaultStateMap::iterator faultIt = faultStates->find(faultStateId);
-      if (faultIt != faultStates->end()) {
-  (*ignoreCondition).second->faultState = (*faultIt).second;
-      }
-      else {
-  errorStream << "ERROR: Failed to configure database, invalid ID for FaultState ("
-        << faultStateId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-  throw(DbException(errorStream.str()));
-      }
-    }
-
-    uint32_t analogDeviceId = (*ignoreCondition).second->analogDeviceId;
-    //    std::cout << "analogDeviceId=" << analogDeviceId << " ";
-
-    if (analogDeviceId != DbIgnoreCondition::INVALID_ID) {
-      DbAnalogDeviceMap::iterator deviceIt = analogDevices->find(analogDeviceId);
-      if (deviceIt != analogDevices->end()) {
-  (*ignoreCondition).second->analogDevice = (*deviceIt).second;
-      }
-      else {
-  errorStream << "ERROR: Failed to configure database, invalid ID for AnalogDevice ("
-        << analogDeviceId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-  throw(DbException(errorStream.str()));
-      }
-    }
-    else {
-      if (faultStateId == DbIgnoreCondition::INVALID_ID) {
-  errorStream << "ERROR: Failed to configure database, invalid ID for FaultState and"
-        << " FaultState for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-  throw(DbException(errorStream.str()));
-      }
-    }
-  }
-
-  // Loop through the ConditionInputs, and assign to the Condition
-  for (DbConditionInputMap::iterator conditionInput = conditionInputs->begin();
-       conditionInput != conditionInputs->end(); ++conditionInput) {
-    uint32_t conditionId = (*conditionInput).second->conditionId;
-
-    DbConditionMap::iterator condition = conditions->find(conditionId);
-    if (condition != conditions->end()) {
-      // Create a map to hold ConditionInputs
-      if (!(*condition).second->conditionInputs) {
-  DbConditionInputMap *conditionInputMap = new DbConditionInputMap();
-  (*condition).second->conditionInputs = DbConditionInputMapPtr(conditionInputMap);
-      }
-      (*condition).second->conditionInputs->
-  insert(std::pair<int, DbConditionInputPtr>((*conditionInput).second->id, (*conditionInput).second));
-    }
-    else {
-      errorStream << "ERROR: Failed to configure database, invalid conditionId ("
-      << conditionId << ") for conditionInput (" <<  (*conditionInput).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-
-    uint32_t faultStateId = (*conditionInput).second->faultStateId;
-
-    DbFaultStateMap::iterator faultIt = faultStates->find(faultStateId);
-    if (faultIt != faultStates->end()) {
-      (*conditionInput).second->faultState = (*faultIt).second;
-    }
-    else {
-      errorStream << "ERROR: Failed to configure database, invalid ID found of FaultState ("
-      << faultStateId << ") for ConditionInput (" <<  (*conditionInput).second->id << ")";
-      throw(DbException(errorStream.str()));
-    }
-  }
 }
 
 /**
@@ -760,123 +861,140 @@ void MpsDb::configureIgnoreConditions() {
  * the fast rules (sent to firmware) and the buffer containing the
  * input updates received from firmware at 360 Hz.
  */
-void MpsDb::configureApplicationCards() {
-  LOG_TRACE("DATABASE", "Configure: ApplicationCards");
-  std::stringstream errorStream;
+void MpsDb::configureApplicationCards()
+{
+    LOG_TRACE("DATABASE", "Configure: ApplicationCards");
+    std::stringstream errorStream;
 
-  // Set the address of the firmware configuration location for each application card; and
-  // the address of the firmware input update location for each application card
-  uint8_t *configBuffer = 0;
-  // uint8_t *updateBuffer = 0;
-  DbApplicationCardPtr aPtr;
-  DbApplicationCardMap::iterator applicationCardIt;
+    // Set the address of the firmware configuration location for each application card; and
+    // the address of the firmware input update location for each application card
+    uint8_t *configBuffer = 0;
+    // uint8_t *updateBuffer = 0;
+    DbApplicationCardPtr aPtr;
+    DbApplicationCardMap::iterator applicationCardIt;
 
-  for (applicationCardIt = applicationCards->begin(); applicationCardIt != applicationCards->end();
-       ++applicationCardIt) {
-    aPtr = (*applicationCardIt).second;
+    for (applicationCardIt = applicationCards->begin();
+        applicationCardIt != applicationCards->end();
+        ++applicationCardIt)
+    {
+        aPtr = (*applicationCardIt).second;
 
-    // Find its crate
-    DbCrateMap::iterator crateIt;
-    crateIt = crates->find(aPtr->crateId);
-    if (crateIt != crates->end()) {
-      aPtr->crate = (*crateIt).second;
+        // Find its crate
+        DbCrateMap::iterator crateIt;
+        crateIt = crates->find(aPtr->crateId);
+        if (crateIt != crates->end())
+            aPtr->crate = (*crateIt).second;
+
+        // Configuration buffer
+        configBuffer = fastConfigurationBuffer + aPtr->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES;
+        aPtr->applicationConfigBuffer = reinterpret_cast<ApplicationConfigBufferBitSet *>(configBuffer);
+
+        // Update buffer
+        // updateBuffer = fwUpdateBuffer.getReadPtr()->at(
+        //   APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES + // Skip header (timestamp + zeroes)
+        //   aPtr->globalId * APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES); // Jump to correct area according to the globalId
+
+        // For debugging purposes only
+        aPtr->applicationUpdateBufferFull = reinterpret_cast<ApplicationUpdateBufferFullBitSet *>(fwUpdateBuffer.getReadPtr());
+
+        // New mapping
+        aPtr->setUpdateBufferPtr(&fwUpdateBuffer);
+
+        // Find the ApplicationType for each card
+        DbApplicationTypeMap::iterator applicationTypeIt = applicationTypes->find(aPtr->applicationTypeId);
+        if (applicationTypeIt != applicationTypes->end())
+            aPtr->applicationType = (*applicationTypeIt).second;
+
+        LOG_TRACE("DATABASE", "AppCard [" << aPtr->globalId << ", " << aPtr->name << "] config/update buffer alloc");
     }
 
-    // Configuration buffer
-    configBuffer = fastConfigurationBuffer + aPtr->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES;
-    aPtr->applicationConfigBuffer = reinterpret_cast<ApplicationConfigBufferBitSet *>(configBuffer);
-
-    // Update buffer
-    // updateBuffer = fwUpdateBuffer.getReadPtr()->at(
-    //   APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES + // Skip header (timestamp + zeroes)
-    //   aPtr->globalId * APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES); // Jump to correct area according to the globalId
-
-    // For debugging purposes only
-    aPtr->applicationUpdateBufferFull = reinterpret_cast<ApplicationUpdateBufferFullBitSet *>(fwUpdateBuffer.getReadPtr());
-
-    // New mapping
-    aPtr->setUpdateBufferPtr(&fwUpdateBuffer);
-
-    // Find the ApplicationType for each card
-    DbApplicationTypeMap::iterator applicationTypeIt = applicationTypes->find(aPtr->applicationTypeId);
-    if (applicationTypeIt != applicationTypes->end()) {
-      aPtr->applicationType = (*applicationTypeIt).second;
+    // Get all devices for each application card, starting with the digital devices
+    // Create a map of digital devices for each DbApplicationCard
+    DbDigitalDeviceMap::iterator digitalDeviceIt;
+    DbDigitalDevicePtr dPtr;
+    for (digitalDeviceIt = digitalDevices->begin();
+        digitalDeviceIt != digitalDevices->end();
+        ++digitalDeviceIt)
+    {
+        dPtr = (*digitalDeviceIt).second;
+        applicationCardIt = applicationCards->find(dPtr->cardId);
+        if (applicationCardIt != applicationCards->end())
+        {
+            aPtr = (*applicationCardIt).second;
+            // Alloc a new map for digital devices if one is not there yet
+            if (!aPtr->digitalDevices)
+            {
+                DbDigitalDeviceMap *digitalDevices = new DbDigitalDeviceMap();
+                aPtr->digitalDevices = DbDigitalDeviceMapPtr(digitalDevices);
+            }
+            // Once the map is there, add the digital device
+            aPtr->digitalDevices->insert(std::pair<int, DbDigitalDevicePtr>(dPtr->id, dPtr));
+            LOG_TRACE("DATABASE", "AppCard [" << aPtr->globalId << ", " << aPtr->name << "], DigitalDevice: " << dPtr->name);
+        }
     }
 
-    LOG_TRACE("DATABASE", "AppCard [" << aPtr->globalId << ", " << aPtr->name << "] config/update buffer alloc");
-  }
+    // Do the same for analog devices
+    DbAnalogDeviceMap::iterator analogDeviceIt;
+    DbAnalogDevicePtr adPtr;
 
-  // Get all devices for each application card, starting with the digital devices
-  // Create a map of digital devices for each DbApplicationCard
-  DbDigitalDeviceMap::iterator digitalDeviceIt;
-  DbDigitalDevicePtr dPtr;
-  for (digitalDeviceIt = digitalDevices->begin(); digitalDeviceIt != digitalDevices->end(); ++digitalDeviceIt) {
-    dPtr = (*digitalDeviceIt).second;
-    applicationCardIt = applicationCards->find(dPtr->cardId);
-    if (applicationCardIt != applicationCards->end()) {
-      aPtr = (*applicationCardIt).second;
-      // Alloc a new map for digital devices if one is not there yet
-      if (!aPtr->digitalDevices) {
-  DbDigitalDeviceMap *digitalDevices = new DbDigitalDeviceMap();
-  aPtr->digitalDevices = DbDigitalDeviceMapPtr(digitalDevices);
-      }
-      // Once the map is there, add the digital device
-      aPtr->digitalDevices->insert(std::pair<int, DbDigitalDevicePtr>(dPtr->id, dPtr));
-      LOG_TRACE("DATABASE", "AppCard [" << aPtr->globalId << ", " << aPtr->name << "], DigitalDevice: " << dPtr->name);
+    for (DbAnalogDeviceMap::iterator analogDeviceIt = analogDevices->begin();
+        analogDeviceIt != analogDevices->end();
+        ++analogDeviceIt)
+    {
+        adPtr = (*analogDeviceIt).second;
+        DbApplicationCardMap::iterator applicationCardIt = applicationCards->find(adPtr->cardId);
+        if (applicationCardIt != applicationCards->end())
+        {
+            aPtr = (*applicationCardIt).second;
+            // Alloc a new map for analog devices if one is not there yet
+            if (aPtr->digitalDevices)
+            {
+                errorStream << "ERROR: Found ApplicationCard with digital AND analog devices,"
+                    << " can't handle that (cardId="
+                    << (*analogDeviceIt).second->cardId << ")";
+                throw(DbException(errorStream.str()));
+            }
+
+            if (!aPtr->analogDevices)
+            {
+                DbAnalogDeviceMap *analogDevices = new DbAnalogDeviceMap();
+                aPtr->analogDevices = DbAnalogDeviceMapPtr(analogDevices);
+            }
+
+            // Once the map is there, add the analog device
+            aPtr->analogDevices->insert(std::pair<int, DbAnalogDevicePtr>(adPtr->id, adPtr));
+            LOG_TRACE("DATABASE", "AppCard [" << aPtr->globalId << ", " << aPtr->name << "], AnalogDevice: " << adPtr->name);
+            adPtr->numChannelsCard = aPtr->applicationType->analogChannelCount;
+        }
     }
-  }
 
-  // Do the same for analog devices
-  DbAnalogDeviceMap::iterator analogDeviceIt;
-  DbAnalogDevicePtr adPtr;
-
-  for (DbAnalogDeviceMap::iterator analogDeviceIt = analogDevices->begin();
-       analogDeviceIt != analogDevices->end(); ++analogDeviceIt) {
-    adPtr = (*analogDeviceIt).second;
-    DbApplicationCardMap::iterator applicationCardIt = applicationCards->find(adPtr->cardId);
-    if (applicationCardIt != applicationCards->end()) {
-      aPtr = (*applicationCardIt).second;
-      // Alloc a new map for analog devices if one is not there yet
-      if (aPtr->digitalDevices) {
-  errorStream << "ERROR: Found ApplicationCard with digital AND analog devices,"
-        << " can't handle that (cardId="
-        << (*analogDeviceIt).second->cardId << ")";
-  throw(DbException(errorStream.str()));
-      }
-      if (!aPtr->analogDevices) {
-  DbAnalogDeviceMap *analogDevices = new DbAnalogDeviceMap();
-  aPtr->analogDevices = DbAnalogDeviceMapPtr(analogDevices);
-      }
-      // Once the map is there, add the analog device
-      aPtr->analogDevices->insert(std::pair<int, DbAnalogDevicePtr>(adPtr->id, adPtr));
-      LOG_TRACE("DATABASE", "AppCard [" << aPtr->globalId << ", " << aPtr->name << "], AnalogDevice: " << adPtr->name);
-      adPtr->numChannelsCard = aPtr->applicationType->analogChannelCount;
+    for (applicationCardIt = applicationCards->begin();
+        applicationCardIt != applicationCards->end();
+        ++applicationCardIt)
+    {
+        (*applicationCardIt).second->configureUpdateBuffers();
     }
-  }
-
-  for (applicationCardIt = applicationCards->begin();
-       applicationCardIt != applicationCards->end();
-       ++applicationCardIt) {
-    (*applicationCardIt).second->configureUpdateBuffers();
-  }
 }
 
-void MpsDb::configureBeamDestinations() {
-  std::cout << "BeamDestinations: ";
-  for (DbBeamDestinationMap::iterator it = beamDestinations->begin();
-       it != beamDestinations->end(); ++it) {
-    std::cout << (*it).second->name << " ";
-    (*it).second->setSoftwareMitigationBuffer( &softwareMitigationBuffer );
-    (*it).second->previousAllowedBeamClass = lowestBeamClass;
-    (*it).second->allowedBeamClass = lowestBeamClass;
-  }
-  std::cout << std::endl;
+void MpsDb::configureBeamDestinations()
+{
+    std::cout << "BeamDestinations: ";
+    for (DbBeamDestinationMap::iterator it = beamDestinations->begin();
+        it != beamDestinations->end();
+        ++it)
+    {
+        std::cout << (*it).second->name << " ";
+        (*it).second->setSoftwareMitigationBuffer( &softwareMitigationBuffer );
+        (*it).second->previousAllowedBeamClass = lowestBeamClass;
+        (*it).second->allowedBeamClass = lowestBeamClass;
+    }
+    std::cout << std::endl;
 }
 
-void MpsDb::clearMitigationBuffer() {
-  for (uint32_t i = 0; i < NUM_DESTINATIONS / 8; ++i) {
-    softwareMitigationBuffer.getWritePtr()->at(i) = 0;
-  }
+void MpsDb::clearMitigationBuffer()
+{
+    for (uint32_t i = 0; i < NUM_DESTINATIONS / 8; ++i)
+        softwareMitigationBuffer.getWritePtr()->at(i) = 0;
 }
 
 /**
@@ -887,78 +1005,92 @@ void MpsDb::clearMitigationBuffer() {
  * referenced element for direct access. This allows the engine to evaluate
  * faults without having to search for entries.
  */
-void MpsDb::configure() {
-  configureAllowedClasses();
-  configureDeviceTypes();
-  configureDeviceInputs();
-  configureFaultStates();
-  configureAnalogDevices();
-  configureFaultInputs();
-  configureIgnoreConditions();
-  configureApplicationCards();
-  configureBeamDestinations();
+void MpsDb::configure()
+{
+    configureAllowedClasses();
+    configureDeviceTypes();
+    configureDeviceInputs();
+    configureFaultStates();
+    configureAnalogDevices();
+    configureFaultInputs();
+    configureIgnoreConditions();
+    configureApplicationCards();
+    configureBeamDestinations();
 }
 
-void MpsDb::forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassId) {
-  DbBeamDestinationMap::iterator beamDestIt = beamDestinations->find(beamDestinationId);
-  if (beamDestIt != beamDestinations->end()) {
-    if (beamClassId != CLEAR_BEAM_CLASS) {
-      DbBeamClassMap::iterator beamClassIt = beamClasses->find(beamClassId);
-      if (beamClassIt != beamClasses->end()) {
-  (*beamDestIt).second->setForceBeamClass((*beamClassIt).second);
-  std::cout << "Force dest["<< beamDestinationId <<"] to class [" << beamClassId << "]" << std::endl;
-      }
-      else {
-  (*beamDestIt).second->resetForceBeamClass();
-  std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
-      }
+void MpsDb::forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassId)
+{
+    DbBeamDestinationMap::iterator beamDestIt = beamDestinations->find(beamDestinationId);
+    if (beamDestIt != beamDestinations->end())
+    {
+        if (beamClassId != CLEAR_BEAM_CLASS)
+        {
+            DbBeamClassMap::iterator beamClassIt = beamClasses->find(beamClassId);
+            if (beamClassIt != beamClasses->end())
+            {
+                (*beamDestIt).second->setForceBeamClass((*beamClassIt).second);
+                std::cout << "Force dest["<< beamDestinationId <<"] to class [" << beamClassId << "]" << std::endl;
+            }
+            else
+            {
+                (*beamDestIt).second->resetForceBeamClass();
+                std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
+            }
+        }
+        else
+        {
+            (*beamDestIt).second->resetForceBeamClass();
+            std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
+        }
     }
-    else {
-      (*beamDestIt).second->resetForceBeamClass();
-      std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
+}
+
+void MpsDb::writeFirmwareConfiguration(bool forceAomAllow)
+{
+    // Write configuration for each application in the system
+    LOG_TRACE("DATABASE", "Writing config to firmware, num applications: " << applicationCards->size());
+    int i = 0;
+    for (DbApplicationCardMap::iterator card = applicationCards->begin();
+        card != applicationCards->end();
+        ++card)
+    {
+        (*card).second->writeConfiguration(forceAomAllow);
+        Firmware::getInstance().writeConfig((*card).second->globalId, fastConfigurationBuffer +
+            (*card).second->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES,
+            APPLICATION_CONFIG_BUFFER_USED_SIZE_BYTES);
+        i++;
     }
-  }
+
+    // Write the timing verifying parameters for each beam class
+    uint32_t time[FW_NUM_BEAM_CLASSES];
+    uint32_t period[FW_NUM_BEAM_CLASSES];
+    uint32_t charge[FW_NUM_BEAM_CLASSES];
+
+    for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+    {
+        time[i] = 1;
+        period[i] = 0;
+        charge[i] = 4294967295;
+    }
+
+    for (DbBeamClassMap::iterator beamClass = beamClasses->begin();
+        beamClass != beamClasses->end();
+        ++beamClass)
+    {
+        time[(*beamClass).second->number] = (*beamClass).second->integrationWindow;
+        period[(*beamClass).second->number] = (*beamClass).second->minPeriod;
+        charge[(*beamClass).second->number] = (*beamClass).second->totalCharge;
+    }
+
+    Firmware::getInstance().writeTimingChecking(time, period, charge);
+
+    // Firmware command to actually switch to the new configuration
+    Firmware::getInstance().switchConfig();
 }
 
-void MpsDb::writeFirmwareConfiguration(bool forceAomAllow) {
-  // Write configuration for each application in the system
-  LOG_TRACE("DATABASE", "Writing config to firmware, num applications: " << applicationCards->size());
-  int i = 0;
-  for (DbApplicationCardMap::iterator card = applicationCards->begin();
-       card != applicationCards->end(); ++card) {
-    (*card).second->writeConfiguration(forceAomAllow);
-    Firmware::getInstance().writeConfig((*card).second->globalId, fastConfigurationBuffer +
-          (*card).second->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES,
-          APPLICATION_CONFIG_BUFFER_USED_SIZE_BYTES);
-    i++;
-  }
-
-  // Write the timing verifying parameters for each beam class
-  uint32_t time[FW_NUM_BEAM_CLASSES];
-  uint32_t period[FW_NUM_BEAM_CLASSES];
-  uint32_t charge[FW_NUM_BEAM_CLASSES];
-
-  for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-    time[i] = 1;
-    period[i] = 0;
-    charge[i] = 4294967295;
-  }
-
-  for (DbBeamClassMap::iterator beamClass = beamClasses->begin();
-       beamClass != beamClasses->end(); ++beamClass) {
-    time[(*beamClass).second->number] = (*beamClass).second->integrationWindow;
-    period[(*beamClass).second->number] = (*beamClass).second->minPeriod;
-    charge[(*beamClass).second->number] = (*beamClass).second->totalCharge;
-  }
-
-  Firmware::getInstance().writeTimingChecking(time, period, charge);
-
-  // Firmware command to actually switch to the new configuration
-  Firmware::getInstance().switchConfig();
-}
-
-void MpsDb::setName(std::string yamlFileName) {
-  name = yamlFileName;
+void MpsDb::setName(std::string yamlFileName)
+{
+    name = yamlFileName;
 }
 
 /**
@@ -966,227 +1098,314 @@ void MpsDb::setName(std::string yamlFileName) {
  * This method opens each table as a YAML::Node and loads all entry contents
  * into the MpsDb maps. Each maps uses the MPS database id as key.
  */
-int MpsDb::load(std::string yamlFileName) {
-  std::stringstream errorStream;
-  YAML::Node doc;
-  std::vector<YAML::Node> nodes;
+int MpsDb::load(std::string yamlFileName)
+{
+    std::stringstream errorStream;
+    YAML::Node doc;
+    std::vector<YAML::Node> nodes;
 
-  LOG_TRACE("DATABASE", "Loading YAML from file " << yamlFileName);
-  try {
-    nodes = YAML::LoadAllFromFile(yamlFileName);
-  } catch (YAML::BadFile &e) {
-    errorStream << "ERROR: Please check if YAML file is readable";
-    throw(DbException(errorStream.str()));
-  } catch (...) {
-    errorStream << "ERROR: Failed to load YAML file ("
-    << yamlFileName << ")";
-    throw(DbException(errorStream.str()));
-  }
-
-  LOG_TRACE("DATABASE", "Parsing YAML");
-  for (std::vector<YAML::Node>::iterator node = nodes.begin();
-       node != nodes.end(); ++node) {
-    std::string s = YAML::Dump(*node);
-    size_t found = s.find(":");
-    if (found == std::string::npos) {
-      errorStream << "ERROR: Can't find Node name in YAML file ("
-      << yamlFileName << ")";
-      throw(DbException(errorStream.str()));
+    LOG_TRACE("DATABASE", "Loading YAML from file " << yamlFileName);
+    try
+    {
+        nodes = YAML::LoadAllFromFile(yamlFileName);
     }
-    std::string nodeName = s.substr(0, found);
-
-    LOG_TRACE("DATABASE", "Parsing \"" << nodeName << "\"");
-
-    if (nodeName == "Crate") {
-      crates = (*node).as<DbCrateMapPtr>();
-    } else if (nodeName == "ApplicationType") {
-      applicationTypes = (*node).as<DbApplicationTypeMapPtr>();
-    } else if (nodeName == "ApplicationCard") {
-      applicationCards = (*node).as<DbApplicationCardMapPtr>();
-    } else if (nodeName == "DigitalChannel") {
-      digitalChannels = (*node).as<DbChannelMapPtr>();
-    } else if (nodeName == "AnalogChannel") {
-      analogChannels = (*node).as<DbChannelMapPtr>();
-    } else if (nodeName == "DeviceType") {
-      deviceTypes = (*node).as<DbDeviceTypeMapPtr>();
-    } else if (nodeName == "DeviceState") {
-      deviceStates = (*node).as<DbDeviceStateMapPtr>();
-    } else if (nodeName == "DigitalDevice") {
-      digitalDevices = (*node).as<DbDigitalDeviceMapPtr>();
-    } else if (nodeName == "DeviceInput") {
-      deviceInputs = (*node).as<DbDeviceInputMapPtr>();
-    } else if (nodeName == "Fault") {
-      faults = (*node).as<DbFaultMapPtr>();
-    } else if (nodeName == "FaultInput") {
-      faultInputs = (*node).as<DbFaultInputMapPtr>();
-    } else if (nodeName == "FaultState") {
-      faultStates = (*node).as<DbFaultStateMapPtr>();
-    } else if (nodeName == "AnalogDevice") {
-      analogDevices = (*node).as<DbAnalogDeviceMapPtr>();
-    } else if (nodeName == "BeamDestination") {
-      beamDestinations = (*node).as<DbBeamDestinationMapPtr>();
-    } else if (nodeName == "MitigationDevice") {
-      // Not implemented
-    } else if (nodeName == "BeamClass") {
-      beamClasses = (*node).as<DbBeamClassMapPtr>();
-    } else if (nodeName == "AllowedClass") {
-      allowedClasses = (*node).as<DbAllowedClassMapPtr>();
-    } else if (nodeName == "Condition") {
-      conditions = (*node).as<DbConditionMapPtr>();
-    } else if (nodeName == "IgnoreCondition") {
-      ignoreConditions = (*node).as<DbIgnoreConditionMapPtr>();
-    } else if (nodeName == "ConditionInput") {
-      conditionInputs = (*node).as<DbConditionInputMapPtr>();
-    } else if (nodeName == "DatabaseInfo") {
-      databaseInfo = (*node).as<DbInfoMapPtr>();
-    } else {
-      // Do not raise exception if the YAML node is known, but
-      // does not need to be loaded by central node engine
-      if (nodeName != "LinkNode") {
-  errorStream << "ERROR: Unknown YAML node name ("
-        << nodeName << ")";
-  throw(DbException(errorStream.str()));
-      }
+    catch (YAML::BadFile &e)
+    {
+        errorStream << "ERROR: Please check if YAML file is readable";
+        throw(DbException(errorStream.str()));
     }
-  }
+    catch (...)
+    {
+        errorStream << "ERROR: Failed to load YAML file ("
+            << yamlFileName << ")";
+        throw(DbException(errorStream.str()));
+    }
 
-  setName(yamlFileName);
+    LOG_TRACE("DATABASE", "Parsing YAML");
+    for (std::vector<YAML::Node>::iterator node = nodes.begin();
+        node != nodes.end();
+        ++node)
+    {
+        std::string s = YAML::Dump(*node);
+        size_t found = s.find(":");
+        if (found == std::string::npos)
+        {
+            errorStream << "ERROR: Can't find Node name in YAML file ("
+                << yamlFileName << ")";
+            throw(DbException(errorStream.str()));
+        }
+        std::string nodeName = s.substr(0, found);
 
-  // Zero out the buffer that holds the firmware configuration
-  //  memset(fastConfigurationBuffer, 0, NUM_APPLICATIONS * APPLICATION_CONFIG_BUFFER_SIZE);
+        LOG_TRACE("DATABASE", "Parsing \"" << nodeName << "\"");
 
-  return 0;
+        if (nodeName == "Crate")
+        {
+            crates = (*node).as<DbCrateMapPtr>();
+        }
+        else if (nodeName == "ApplicationType")
+        {
+            applicationTypes = (*node).as<DbApplicationTypeMapPtr>();
+        }
+        else if (nodeName == "ApplicationCard")
+        {
+            applicationCards = (*node).as<DbApplicationCardMapPtr>();
+        }
+        else if (nodeName == "DigitalChannel")
+        {
+            digitalChannels = (*node).as<DbChannelMapPtr>();
+        }
+        else if (nodeName == "AnalogChannel")
+        {
+            analogChannels = (*node).as<DbChannelMapPtr>();
+        }
+        else if (nodeName == "DeviceType")
+        {
+            deviceTypes = (*node).as<DbDeviceTypeMapPtr>();
+        }
+        else if (nodeName == "DeviceState")
+        {
+            deviceStates = (*node).as<DbDeviceStateMapPtr>();
+        }
+        else if (nodeName == "DigitalDevice")
+        {
+            digitalDevices = (*node).as<DbDigitalDeviceMapPtr>();
+        }
+        else if (nodeName == "DeviceInput")
+        {
+            deviceInputs = (*node).as<DbDeviceInputMapPtr>();
+        }
+        else if (nodeName == "Fault")
+        {
+            faults = (*node).as<DbFaultMapPtr>();
+        }
+        else if (nodeName == "FaultInput")
+        {
+            faultInputs = (*node).as<DbFaultInputMapPtr>();
+        }
+        else if (nodeName == "FaultState")
+        {
+            faultStates = (*node).as<DbFaultStateMapPtr>();
+        }
+        else if (nodeName == "AnalogDevice")
+        {
+            analogDevices = (*node).as<DbAnalogDeviceMapPtr>();
+        }
+        else if (nodeName == "BeamDestination")
+        {
+            beamDestinations = (*node).as<DbBeamDestinationMapPtr>();
+        }
+        else if (nodeName == "MitigationDevice")
+        {
+            // Not implemented
+        }
+        else if (nodeName == "BeamClass")
+        {
+            beamClasses = (*node).as<DbBeamClassMapPtr>();
+        }
+        else if (nodeName == "AllowedClass")
+        {
+            allowedClasses = (*node).as<DbAllowedClassMapPtr>();
+        }
+        else if (nodeName == "Condition")
+        {
+            conditions = (*node).as<DbConditionMapPtr>();
+        }
+        else if (nodeName == "IgnoreCondition")
+        {
+            ignoreConditions = (*node).as<DbIgnoreConditionMapPtr>();
+        }
+        else if (nodeName == "ConditionInput")
+        {
+            conditionInputs = (*node).as<DbConditionInputMapPtr>();
+        }
+        else if (nodeName == "DatabaseInfo")
+        {
+            databaseInfo = (*node).as<DbInfoMapPtr>();
+        }
+        else
+        {
+            // Do not raise exception if the YAML node is known, but
+            // does not need to be loaded by central node engine
+            if (nodeName != "LinkNode")
+            {
+                errorStream << "ERROR: Unknown YAML node name ("
+                    << nodeName << ")";
+                throw(DbException(errorStream.str()));
+            }
+        }
+    }
+
+    setName(yamlFileName);
+
+    // Zero out the buffer that holds the firmware configuration
+    //  memset(fastConfigurationBuffer, 0, NUM_APPLICATIONS * APPLICATION_CONFIG_BUFFER_SIZE);
+
+    return 0;
 }
 
 /**
  * Print out the digital/analog inputs (DbFaultInput and DbAnalogDevices)
  */
-void MpsDb::showFaults() {
-  std::cout << "+-------------------------------------------------------" << std::endl;
-  std::cout << "| Faults: " << std::endl;
-  std::cout << "+-------------------------------------------------------" << std::endl;
-  std::unique_lock<std::mutex> lock(_mutex);
-  for (DbFaultMap::iterator fault = faults->begin();
-       fault != faults->end(); ++fault) {
-    showFault((*fault).second);
-  }
-  std::cout << "+-------------------------------------------------------" << std::endl;
+void MpsDb::showFaults()
+{
+    std::cout << "+-------------------------------------------------------" << std::endl;
+    std::cout << "| Faults: " << std::endl;
+    std::cout << "+-------------------------------------------------------" << std::endl;
+    std::unique_lock<std::mutex> lock(_mutex);
+    for (DbFaultMap::iterator fault = faults->begin();
+        fault != faults->end();
+        ++fault)
+    {
+        showFault((*fault).second);
+    }
+    std::cout << "+-------------------------------------------------------" << std::endl;
 }
 
-void MpsDb::showFastUpdateBuffer(uint32_t begin, uint32_t size) {
-  for (uint32_t address = begin; address < begin + size; ++address) {
-    if (address % 16 == 0) {
-      std::cout << std::endl;
-      std::cout << std::setw(5) << std::hex << address << std::dec << " ";
-    }
-
-    std::cout << " ";
-
-    char c1 = fwUpdateBuffer.getReadPtr()->at(address) & 0x0F;
-    char c2 = (fwUpdateBuffer.getReadPtr()->at(address) & 0xF0) >> 4;
-    if (c1 <= 9) c1 += 0x30; else c1 = 0x61 + (c1 - 10);
-    if (c2 <= 9) c2 += 0x30; else c2 = 0x61 + (c2 - 10);
-    std::cout << c1 << c2;
-  }
-}
-
-void MpsDb::showFault(DbFaultPtr fault) {
-  std::cout << "| " << fault->name << std::endl;
-  if (!fault->faultInputs) {
-    std::cout << "| - WARNING: No inputs to this fault" << std::endl;
-  }
-  else {
-    for (DbFaultInputMap::iterator input = fault->faultInputs->begin();
-   input != fault->faultInputs->end(); ++input) {
-      int deviceId = (*input).second->deviceId;
-      DbDigitalDeviceMap::iterator digitalDevice = digitalDevices->find(deviceId);
-      if (digitalDevice == digitalDevices->end()) {
-  // If no inputs, then this could be an analog device
-  DbAnalogDeviceMap::iterator analogDevice = analogDevices->find(deviceId);
-  if (analogDevice == analogDevices->end()) {
-    std::cout << "| - WARNING: No digital/analog devices for this fault!";
-  }
-  else {
-    std::cout << "| - Input[" << (*analogDevice).second->name
-        << "], Bypass[";
-    if (!(*analogDevice).second->bypass) {
-      std::cout << "WARNING: NO BYPASS INFO]";
-    }
-    else {
-      for (uint32_t i = 0; i < ANALOG_DEVICE_NUM_THRESHOLDS; ++i) {
-        if ((*analogDevice).second->bypass[i]->status == BYPASS_VALID) {
-    std::cout << "V";
+void MpsDb::showFastUpdateBuffer(uint32_t begin, uint32_t size)
+{
+    for (uint32_t address = begin; address < begin + size; ++address)
+    {
+        if (address % 16 == 0)
+        {
+            std::cout << std::endl;
+            std::cout << std::setw(5) << std::hex << address << std::dec << " ";
         }
-        else {
-    std::cout << "E";
+
+        std::cout << " ";
+
+        char c1 = fwUpdateBuffer.getReadPtr()->at(address) & 0x0F;
+        char c2 = (fwUpdateBuffer.getReadPtr()->at(address) & 0xF0) >> 4;
+
+        if (c1 <= 9)
+            c1 += 0x30;
+        else
+            c1 = 0x61 + (c1 - 10);
+
+        if (c2 <= 9)
+            c2 += 0x30;
+        else
+            c2 = 0x61 + (c2 - 10);
+
+        std::cout << c1 << c2;
+    }
+}
+
+void MpsDb::showFault(DbFaultPtr fault)
+{
+    std::cout << "| " << fault->name << std::endl;
+    if (!fault->faultInputs)
+    {
+        std::cout << "| - WARNING: No inputs to this fault" << std::endl;
+    }
+    else
+    {
+        for (DbFaultInputMap::iterator input = fault->faultInputs->begin();
+            input != fault->faultInputs->end();
+            ++input)
+        {
+            int deviceId = (*input).second->deviceId;
+            DbDigitalDeviceMap::iterator digitalDevice = digitalDevices->find(deviceId);
+            if (digitalDevice == digitalDevices->end())
+            {
+                // If no inputs, then this could be an analog device
+                DbAnalogDeviceMap::iterator analogDevice = analogDevices->find(deviceId);
+                if (analogDevice == analogDevices->end())
+                {
+                    std::cout << "| - WARNING: No digital/analog devices for this fault!";
+                }
+                else
+                {
+                    std::cout << "| - Input[" << (*analogDevice).second->name
+                        << "], Bypass[";
+                    if (!(*analogDevice).second->bypass)
+                    {
+                        std::cout << "WARNING: NO BYPASS INFO]";
+                    }
+                    else
+                    {
+                        for (uint32_t i = 0; i < ANALOG_DEVICE_NUM_THRESHOLDS; ++i)
+                        {
+                            if ((*analogDevice).second->bypass[i]->status == BYPASS_VALID)
+                            {
+                                std::cout << "V";
+                            }
+                            else
+                            {
+                                std::cout << "E";
+                            }
+                        }
+                        std::cout << "]";
+                    }
+                    std::cout << std::endl;
+                }
+            }
+            else
+            {
+                for (DbDeviceInputMap::iterator devInput =
+                    (*digitalDevice).second->inputDevices->begin();
+                devInput != (*digitalDevice).second->inputDevices->end(); ++devInput)
+                {
+                    std::cout << "| - Input[" << (*devInput).second->id
+                        << "], Position[" << (*devInput).second->bitPosition
+                        << "], Bypass[";
+
+                    if (!(*devInput).second->bypass)
+                    {
+                        std::cout << "WARNING: NO BYPASS INFO]";
+                    }
+                    else
+                    {
+                        if ((*devInput).second->bypass->status == BYPASS_VALID)
+                            std::cout << "VALID]";
+                        else
+                            std::cout << "EXPIRED]";
+                    }
+                    std::cout << std::endl;
+                }
+            }
         }
-      }
-      std::cout << "]";
     }
-    std::cout << std::endl;
-  }
-      }
-      else {
-  for (DbDeviceInputMap::iterator devInput =
-         (*digitalDevice).second->inputDevices->begin();
-       devInput != (*digitalDevice).second->inputDevices->end(); ++devInput) {
-    std::cout << "| - Input[" << (*devInput).second->id
-        << "], Position[" << (*devInput).second->bitPosition
-        << "], Bypass[";
-
-    if (!(*devInput).second->bypass) {
-      std::cout << "WARNING: NO BYPASS INFO]";
-    }
-    else {
-      if ((*devInput).second->bypass->status == BYPASS_VALID) {
-        std::cout << "VALID]";
-      }
-      else {
-        std::cout << "EXPIRED]";
-      }
-    }
-    std::cout << std::endl;
-  }
-      }
-    }
-  }
 }
 
-void MpsDb::showMitigation() {
-  std::unique_lock<std::mutex> lock(_mutex);
+void MpsDb::showMitigation()
+{
+    std::unique_lock<std::mutex> lock(_mutex);
 
-  std::cout << "Allowed power classes at beam destinations:" << std::endl;
-  for (DbBeamDestinationMap::iterator mitDevice = beamDestinations->begin();
-       mitDevice != beamDestinations->end(); ++mitDevice) {
-    std::cout << "  " << (*mitDevice).second->name << ": " << (*mitDevice).second->allowedBeamClass->number << std::endl;
-  }
+    std::cout << "Allowed power classes at beam destinations:" << std::endl;
+    for (DbBeamDestinationMap::iterator mitDevice = beamDestinations->begin();
+        mitDevice != beamDestinations->end();
+        ++mitDevice)
+    {
+        std::cout << "  " << (*mitDevice).second->name << ": " << (*mitDevice).second->allowedBeamClass->number << std::endl;
+    }
 }
 
-void MpsDb::showInfo() {
-  std::unique_lock<std::mutex> lock(_mutex);
+void MpsDb::showInfo()
+{
+    std::unique_lock<std::mutex> lock(_mutex);
 
-  std::cout << "Current database information:" << std::endl;
-  std::cout << "File: " << name << std::endl;
-  std::cout << "Update counter: " << _updateCounter << std::endl;
-  std::cout << "Input update timeout " << _inputUpdateTimeout << " usec" << std::endl;
-  printPCChangeInfo();
+    std::cout << "Current database information:" << std::endl;
+    std::cout << "File: " << name << std::endl;
+    std::cout << "Update counter: " << _updateCounter << std::endl;
+    std::cout << "Input update timeout " << _inputUpdateTimeout << " usec" << std::endl;
+    printPCChangeInfo();
 
-  printMap<DbInfoMapPtr, DbInfoMap::iterator>
-    (std::cout, databaseInfo, "DatabaseInfo");
+    printMap<DbInfoMapPtr, DbInfoMap::iterator>
+        (std::cout, databaseInfo, "DatabaseInfo");
 
-  _inputUpdateTime.show();
-  fwUpdateTimer.show();
-  mitigationTxTime.show();
-  AnalogDeviceUpdateTime.show();
-  DeviceInputUpdateTime.show();
-  AppCardDigitalUpdateTime.show();
-  AppCardAnalogUpdateTime.show();
+    _inputUpdateTime.show();
+    fwUpdateTimer.show();
+    mitigationTxTime.show();
+    AnalogDeviceUpdateTime.show();
+    DeviceInputUpdateTime.show();
+    AppCardDigitalUpdateTime.show();
+    AppCardAnalogUpdateTime.show();
 
-  std::cout << "Max TimeStamp diff    : " << _maxDiff << std::endl;
-  _maxDiff = 0;
-  std::cout << "Current TimeStamp diff: " << _diff << std::endl;
-  std::cout << "Diff > 12ms count     : " << _diffCount << std::endl;
-  std::cout << "Update timout counter : " << _updateTimeoutCounter << std::endl;
+    std::cout << "Max TimeStamp diff    : " << _maxDiff << std::endl;
+    _maxDiff = 0;
+    std::cout << "Current TimeStamp diff: " << _diff << std::endl;
+    std::cout << "Diff > 12ms count     : " << _diffCount << std::endl;
+    std::cout << "Update timout counter : " << _updateTimeoutCounter << std::endl;
 }
 
 void MpsDb::printPCChangeLastPacketInfo() const
@@ -1209,7 +1428,7 @@ void MpsDb::printPCChangeInfo() const
     std::cout << "- Flag error counters:" << std::endl;
     auto countIt = _pcFlagsCounters.begin();
     auto labelIt = Firmware::PcChangePacketFlagsLabels.begin();
-    for( ; (countIt != _pcFlagsCounters.end()) && (labelIt != Firmware::PcChangePacketFlagsLabels.end()); ++countIt, ++labelIt )
+    for(; (countIt != _pcFlagsCounters.end()) && (labelIt != Firmware::PcChangePacketFlagsLabels.end()); ++countIt, ++labelIt )
         std::cout << "  * " << std::left << std::setw(13) << *labelIt << " = " << *countIt << std::endl;
     std::cout << "- Last packet content: " << std::endl;
     printPCChangeLastPacketInfo();
@@ -1245,92 +1464,93 @@ void MpsDb::printPCCounters() const
 }
 
 void MpsDb::clearUpdateTime() {
-  _clearUpdateTime = true;
+    _clearUpdateTime = true;
 }
 
 long MpsDb::getMaxUpdateTime() {
-  return static_cast<int>( _inputUpdateTime.getAllMaxPeriod() * 1e6 );
+    return static_cast<int>( _inputUpdateTime.getAllMaxPeriod() * 1e6 );
 }
 
 long MpsDb::getAvgUpdateTime() {
-  return static_cast<int>( _inputUpdateTime.getMeanPeriod() * 1e6 );
+    return static_cast<int>( _inputUpdateTime.getMeanPeriod() * 1e6 );
 }
 
 long MpsDb::getMaxFwUpdatePeriod() {
-  return static_cast<int>( fwUpdateTimer.getAllMaxPeriod() * 1e6 );
+    return static_cast<int>( fwUpdateTimer.getAllMaxPeriod() * 1e6 );
 }
 
 long MpsDb::getAvgFwUpdatePeriod() {
-  return static_cast<int>( fwUpdateTimer.getMeanPeriod() * 1e6 );
+    return static_cast<int>( fwUpdateTimer.getMeanPeriod() * 1e6 );
 }
 
-std::ostream & operator<<(std::ostream &os, MpsDb * const mpsDb) {
-  os << "Name: " << mpsDb->name << std::endl;
+std::ostream & operator<<(std::ostream &os, MpsDb * const mpsDb)
+{
+    os << "Name: " << mpsDb->name << std::endl;
 
-  mpsDb->printMap<DbCrateMapPtr, DbCrateMap::iterator>
-    (os, mpsDb->crates, "Crate");
+    mpsDb->printMap<DbCrateMapPtr, DbCrateMap::iterator>
+        (os, mpsDb->crates, "Crate");
 
-  mpsDb->printMap<DbApplicationTypeMapPtr, DbApplicationTypeMap::iterator>
-    (os, mpsDb->applicationTypes, "ApplicationType");
+    mpsDb->printMap<DbApplicationTypeMapPtr, DbApplicationTypeMap::iterator>
+        (os, mpsDb->applicationTypes, "ApplicationType");
 
-  mpsDb->printMap<DbApplicationCardMapPtr, DbApplicationCardMap::iterator>
-    (os, mpsDb->applicationCards, "ApplicationCard");
+    mpsDb->printMap<DbApplicationCardMapPtr, DbApplicationCardMap::iterator>
+        (os, mpsDb->applicationCards, "ApplicationCard");
 
-  mpsDb->printMap<DbChannelMapPtr, DbChannelMap::iterator>
-    (os, mpsDb->digitalChannels, "DigitalChannel");
+    mpsDb->printMap<DbChannelMapPtr, DbChannelMap::iterator>
+        (os, mpsDb->digitalChannels, "DigitalChannel");
 
-  mpsDb->printMap<DbChannelMapPtr, DbChannelMap::iterator>
-    (os, mpsDb->analogChannels, "AnalogChannel");
+    mpsDb->printMap<DbChannelMapPtr, DbChannelMap::iterator>
+        (os, mpsDb->analogChannels, "AnalogChannel");
 
-  mpsDb->printMap<DbDeviceTypeMapPtr, DbDeviceTypeMap::iterator>
-    (os, mpsDb->deviceTypes, "DeviceType");
+    mpsDb->printMap<DbDeviceTypeMapPtr, DbDeviceTypeMap::iterator>
+        (os, mpsDb->deviceTypes, "DeviceType");
 
-  mpsDb->printMap<DbDeviceStateMapPtr, DbDeviceStateMap::iterator>
-    (os, mpsDb->deviceStates, "DeviceState");
+    mpsDb->printMap<DbDeviceStateMapPtr, DbDeviceStateMap::iterator>
+        (os, mpsDb->deviceStates, "DeviceState");
 
-  mpsDb->printMap<DbDigitalDeviceMapPtr, DbDigitalDeviceMap::iterator>
-    (os, mpsDb->digitalDevices, "DigitalDevice");
+    mpsDb->printMap<DbDigitalDeviceMapPtr, DbDigitalDeviceMap::iterator>
+        (os, mpsDb->digitalDevices, "DigitalDevice");
 
-  mpsDb->printMap<DbDeviceInputMapPtr, DbDeviceInputMap::iterator>
-    (os, mpsDb->deviceInputs, "DeviceInput");
+    mpsDb->printMap<DbDeviceInputMapPtr, DbDeviceInputMap::iterator>
+        (os, mpsDb->deviceInputs, "DeviceInput");
 
-  mpsDb->printMap<DbFaultMapPtr, DbFaultMap::iterator>
-    (os, mpsDb->faults, "Fault");
+    mpsDb->printMap<DbFaultMapPtr, DbFaultMap::iterator>
+        (os, mpsDb->faults, "Fault");
 
-  mpsDb->printMap<DbFaultInputMapPtr, DbFaultInputMap::iterator>
-    (os, mpsDb->faultInputs, "FaultInput");
+    mpsDb->printMap<DbFaultInputMapPtr, DbFaultInputMap::iterator>
+        (os, mpsDb->faultInputs, "FaultInput");
 
-  mpsDb->printMap<DbFaultStateMapPtr, DbFaultStateMap::iterator>
-    (os, mpsDb->faultStates, "FaultState");
+    mpsDb->printMap<DbFaultStateMapPtr, DbFaultStateMap::iterator>
+        (os, mpsDb->faultStates, "FaultState");
 
-  mpsDb->printMap<DbAnalogDeviceMapPtr, DbAnalogDeviceMap::iterator>
-    (os, mpsDb->analogDevices, "AnalogDevice");
+    mpsDb->printMap<DbAnalogDeviceMapPtr, DbAnalogDeviceMap::iterator>
+        (os, mpsDb->analogDevices, "AnalogDevice");
 
-  mpsDb->printMap<DbBeamDestinationMapPtr, DbBeamDestinationMap::iterator>
-    (os, mpsDb->beamDestinations, "BeamDestination");
+    mpsDb->printMap<DbBeamDestinationMapPtr, DbBeamDestinationMap::iterator>
+        (os, mpsDb->beamDestinations, "BeamDestination");
 
-  mpsDb->printMap<DbBeamClassMapPtr, DbBeamClassMap::iterator>
-    (os, mpsDb->beamClasses, "BeamClass");
+    mpsDb->printMap<DbBeamClassMapPtr, DbBeamClassMap::iterator>
+        (os, mpsDb->beamClasses, "BeamClass");
 
-  mpsDb->printMap<DbAllowedClassMapPtr, DbAllowedClassMap::iterator>
-    (os, mpsDb->allowedClasses, "AllowedClass");
+    mpsDb->printMap<DbAllowedClassMapPtr, DbAllowedClassMap::iterator>
+        (os, mpsDb->allowedClasses, "AllowedClass");
 
-  mpsDb->printMap<DbConditionMapPtr, DbConditionMap::iterator>
-    (os, mpsDb->conditions, "Conditions");
+    mpsDb->printMap<DbConditionMapPtr, DbConditionMap::iterator>
+        (os, mpsDb->conditions, "Conditions");
 
-  mpsDb->printMap<DbConditionInputMapPtr, DbConditionInputMap::iterator>
-    (os, mpsDb->conditionInputs, "ConditionInputs");
+    mpsDb->printMap<DbConditionInputMapPtr, DbConditionInputMap::iterator>
+        (os, mpsDb->conditionInputs, "ConditionInputs");
 
-  mpsDb->printMap<DbIgnoreConditionMapPtr, DbIgnoreConditionMap::iterator>
-    (os, mpsDb->ignoreConditions, "IgnoreConditions");
+    mpsDb->printMap<DbIgnoreConditionMapPtr, DbIgnoreConditionMap::iterator>
+        (os, mpsDb->ignoreConditions, "IgnoreConditions");
 
-  return os;
+    return os;
 }
 
 std::vector<uint8_t> MpsDb::getFastUpdateBuffer()
 {
-  std::unique_lock<std::mutex> lock(*(fwUpdateBuffer.getMutex()));
-  return std::vector<uint8_t>( fwUpdateBuffer.getReadPtr()->begin(), fwUpdateBuffer.getReadPtr()->end() );
+    std::unique_lock<std::mutex> lock(*(fwUpdateBuffer.getMutex()));
+    return std::vector<uint8_t>( fwUpdateBuffer.getReadPtr()->begin(), fwUpdateBuffer.getReadPtr()->end() );
 }
 
 void MpsDb::fwUpdateReader()
@@ -1354,30 +1574,29 @@ void MpsDb::fwUpdateReader()
         }
 
 
-  uint32_t expected_size = APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES +
-    NUM_APPLICATIONS *
-    APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES;
-  uint32_t received_size = 0;
+        uint32_t expected_size = APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES +
+            NUM_APPLICATIONS *
+            APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES;
+        uint32_t received_size = 0;
 
-  while (received_size != expected_size)
-    {
-      received_size = Firmware::getInstance().readUpdateStream(fwUpdateBuffer.getWritePtr()->data(),
-                     expected_size, _inputUpdateTimeout);
-#ifndef FW_ENABLED
-      if (!run) {
-        std::cout << "FW Update Data reader interrupted" << std::endl;
-        return;
-      }
-#endif
-      if (received_size == 0)
+        while (received_size != expected_size)
         {
-    ++_updateTimeoutCounter;
+            received_size = Firmware::getInstance().readUpdateStream(fwUpdateBuffer.getWritePtr()->data(),
+                expected_size, _inputUpdateTimeout);
+#ifndef FW_ENABLED
+            if (!run)
+            {
+                std::cout << "FW Update Data reader interrupted" << std::endl;
+                return;
+            }
+#endif
+            if (received_size == 0)
+                ++_updateTimeoutCounter;
         }
-    }
 
         fwUpdateBuffer.doneWriting();
         fwUpdateTimer.tick();
-  fwUpdateTimer.start();
+        fwUpdateTimer.start();
     }
 }
 
@@ -1388,7 +1607,8 @@ void MpsDb::fwPCChangeReader()
     // 1k buffer, more than enough for "pc_change_t".
     uint8_t buffer[1024];
 
-    while(run) {
+    while(run)
+    {
         int64_t got {0};
 
         // Try to read, with a 10ms timeout, until we get a packet
@@ -1399,12 +1619,15 @@ void MpsDb::fwPCChangeReader()
             // Extract the message information
             Firmware::pc_change_t* pData { (Firmware::pc_change_t*)(buffer) };
 
-            if (_pcChangeFirstPacket) {
+            if (_pcChangeFirstPacket)
+            {
                 // On the first packet, we can not compare it with a previous one
                 // so, we only count it as valid.
                 ++_pcChangeCounter;
                 _pcChangeFirstPacket = false;
-            } else {
+            }
+            else
+            {
                 // Calculate the difference between the tag number of the current
                 // and previous packet. This difference will be:
                 // == 1 : Ok, valid packet.
@@ -1435,15 +1658,19 @@ void MpsDb::fwPCChangeReader()
 
             // Update the flag counters
             for (std::size_t i {0}; i < _pcFlagsCounters.size(); ++i)
+            {
                 if (errors & (1<<i))
                     ++_pcFlagsCounters[i];
+            }
 
             // Valid packets doesn't have MonitorReady errors.
             // Count the number of packet that don't have MonitorReady errors, and increase the
             // corresponding power class transition counters.
-            if (!(errors & 0x01)) {
+            if (!(errors & 0x01))
+            {
                 uint64_t pcw { _pcChangePowerClass };
-                for (std::size_t dest {0}; dest < NUM_DESTINATIONS; ++dest) {
+                for (std::size_t dest {0}; dest < NUM_DESTINATIONS; ++dest)
+                {
                     uint8_t pc { static_cast<uint8_t>( pcw & ( (1<<POWER_CLASS_BIT_SIZE) - 1) ) };
                     ++_pcCounters[dest][pc];
                     pcw >>= POWER_CLASS_BIT_SIZE;
@@ -1451,10 +1678,12 @@ void MpsDb::fwPCChangeReader()
             }
 
             // Print the received packet content if the debug flag is set
-            if (_pcChangeDebug) {
+            if (_pcChangeDebug)
+            {
                 std::cout << "== Power Class Change Message ====" << std::endl;
                 // Print packet bytes in hex
-                for(std::size_t i {0}; i < sizeof(Firmware::pc_change_t); ++i) {
+                for(std::size_t i {0}; i < sizeof(Firmware::pc_change_t); ++i)
+                {
                     if (0 != i && 0 == i % 8)
                         std::cout << std::endl;
                     std::cout << std::setw(2) << std::setfill('0') << std::hex << unsigned(buffer[i]) << std::dec << " ";
@@ -1466,7 +1695,9 @@ void MpsDb::fwPCChangeReader()
                 std::cout << "==================================" << std::endl;
             }
 
-        } else {
+        }
+        else
+        {
             // Increment bad size counter
             ++_pcChangeBadSizeCounter;
         }
@@ -1482,29 +1713,29 @@ void MpsDb::PCChangeSetDebug(bool debug)
 
 void MpsDb::mitigationWriter()
 {
-  std::cout << "Mitigation writer started" << std::endl;
+    std::cout << "Mitigation writer started" << std::endl;
 
-  for(;;)
-  {
-      {
-          std::unique_lock<std::mutex> lock(*(softwareMitigationBuffer.getMutex()));
-          while(!softwareMitigationBuffer.isReadReady())
-          {
-              softwareMitigationBuffer.getCondVar()->wait_for( lock, std::chrono::milliseconds(5) );
-              if(!run)
-              {
-                  std::cout << "Mitigation writer interrupted" << std::endl;
-                  return;
-              }
-          }
-      }
+    for(;;)
+    {
+        {
+            std::unique_lock<std::mutex> lock(*(softwareMitigationBuffer.getMutex()));
+            while(!softwareMitigationBuffer.isReadReady())
+            {
+                softwareMitigationBuffer.getCondVar()->wait_for( lock, std::chrono::milliseconds(5) );
+                if(!run)
+                {
+                    std::cout << "Mitigation writer interrupted" << std::endl;
+                    return;
+                }
+            }
+        }
 
-    // Write the mitigation to FW
-    mitigationTxTime.start();
-    Firmware::getInstance().writeMitigation(softwareMitigationBuffer.getReadPtr()->data());
-    mitigationTxTime.tick();
+        // Write the mitigation to FW
+        mitigationTxTime.start();
+        Firmware::getInstance().writeMitigation(softwareMitigationBuffer.getReadPtr()->data());
+        mitigationTxTime.tick();
 
-    softwareMitigationBuffer.doneReading();
+        softwareMitigationBuffer.doneReading();
 
-  }
+    }
 }

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -81,6 +81,9 @@ MpsDb::MpsDb(uint32_t inputUpdateTimeout)
 
     if( pthread_setname_np( mitigationThread.native_handle(), "MitWriter" ) )
         perror( "pthread_setname_np failed for mitigationThread" );
+
+    if( pthread_setname_np( fwPCChangeThread.native_handle(), "PCChange" ) )
+        perror( "pthread_setname_np failed for fwPCChangeThread" );
   }
 }
 

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -138,7 +138,7 @@ void MpsDb::updateInputs() {
             if(!run)
             {
                 std::cout << "FW Update Data reader interrupted" << std::endl;
-		return;
+    return;
             }
         }
     }
@@ -212,7 +212,7 @@ void MpsDb::configureAllowedClasses() {
     DbBeamClassMap::iterator beamIt = beamClasses->find(id);
     if (beamIt == beamClasses->end()) {
       errorStream <<  "ERROR: Failed to configure database, invalid ID found for BeamClass ("
-		  << id << ") for AllowedClass (" << (*it).second->id << ")";
+      << id << ") for AllowedClass (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
     (*it).second->beamClass = (*beamIt).second;
@@ -221,7 +221,7 @@ void MpsDb::configureAllowedClasses() {
     DbBeamDestinationMap::iterator beamDestIt = beamDestinations->find(id);
     if (beamDestIt == beamDestinations->end()) {
       errorStream << "ERROR: Failed to configure database, invalid ID found for BeamDestinations ("
-		  << id << ") for AllowedClass (" << (*it).second->id << ")";
+      << id << ") for AllowedClass (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
     (*it).second->beamDestination = (*beamDestIt).second;
@@ -237,11 +237,11 @@ void MpsDb::configureAllowedClasses() {
     if (digFaultIt != faultStates->end()) {
       // Create a map to hold deviceInput for the digitalDevice
       if (!(*digFaultIt).second->allowedClasses) {
-	DbAllowedClassMap *faultAllowedClasses = new DbAllowedClassMap();
-	(*digFaultIt).second->allowedClasses = DbAllowedClassMapPtr(faultAllowedClasses);
+  DbAllowedClassMap *faultAllowedClasses = new DbAllowedClassMap();
+  (*digFaultIt).second->allowedClasses = DbAllowedClassMapPtr(faultAllowedClasses);
       }
       (*digFaultIt).second->allowedClasses->insert(std::pair<int, DbAllowedClassPtr>((*it).second->id,
-										     (*it).second));
+                         (*it).second));
     }
   }
 }
@@ -256,11 +256,11 @@ void MpsDb::configureDeviceTypes() {
     if (deviceType != deviceTypes->end()) {
       // Create a map to hold deviceStates for the deviceType
       if (!(*deviceType).second->deviceStates) {
-	DbDeviceStateMap *deviceStates = new DbDeviceStateMap();
-	(*deviceType).second->deviceStates = DbDeviceStateMapPtr(deviceStates);
+  DbDeviceStateMap *deviceStates = new DbDeviceStateMap();
+  (*deviceType).second->deviceStates = DbDeviceStateMapPtr(deviceStates);
       }
       (*deviceType).second->deviceStates->insert(std::pair<int, DbDeviceStatePtr>((*it).second->id,
-										  (*it).second));
+                      (*it).second));
     }
   }
 }
@@ -277,7 +277,7 @@ void MpsDb::configureDeviceInputs() {
     DbDigitalDeviceMap::iterator deviceIt = digitalDevices->find(id);
     if (deviceIt == digitalDevices->end()) {
       errorStream << "ERROR: Failed to configure database, invalid ID found for DigitalDevice ("
-		  << id << ") for DeviceInput (" << (*it).second->id << ")";
+      << id << ") for DeviceInput (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
 
@@ -298,21 +298,21 @@ void MpsDb::configureDeviceInputs() {
       // Extra check to make sure the digitalDevice has only one input, if
       // it has evaluation set to FAST
       if ((*deviceIt).second->evaluation == FAST_EVALUATION) {
-	errorStream << "ERROR: Failed to configure database, found DigitalDevice ("
-		    << id << ") set for FAST_EVALUATION with multiple inputs. Must have single input.";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Failed to configure database, found DigitalDevice ("
+        << id << ") set for FAST_EVALUATION with multiple inputs. Must have single input.";
+  throw(DbException(errorStream.str()));
       }
     }
     (*deviceIt).second->inputDevices->insert(std::pair<int, DbDeviceInputPtr>((*it).second->id,
-									      (*it).second));
+                        (*it).second));
     LOG_TRACE("DATABASE", "Adding DeviceInput (" << (*it).second->id << ") to "
-	      " DigitalDevice (" << (*deviceIt).second->id << ")");
+        " DigitalDevice (" << (*deviceIt).second->id << ")");
 
     int channelId = (*it).second->channelId;
     DbChannelMap::iterator channelIt = digitalChannels->find(channelId);
     if (channelIt == digitalChannels->end()) {
       errorStream << "ERROR: Failed to configure database, invalid ID found for Channel ("
-		  << channelId << ") for DeviceInput (" << (*it).second->id << ")";
+      << channelId << ") for DeviceInput (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
     (*it).second->channel = (*channelIt).second;
@@ -329,7 +329,7 @@ void MpsDb::configureDeviceInputs() {
     }
     else {
       errorStream << "ERROR: Failed to configure database, invalid deviceTypeId ("
-		  << typeId << ") for DigitalDevice (" <<  (*it).second->id << ")";
+      << typeId << ") for DigitalDevice (" <<  (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
   }
@@ -350,114 +350,114 @@ void MpsDb::configureFaultInputs() {
     if (deviceIt == digitalDevices->end()) {
       DbAnalogDeviceMap::iterator aDeviceIt = analogDevices->find(id);
       if (aDeviceIt == analogDevices->end()) {
-	errorStream << "ERROR: Failed to find DigitalDevice/AnalogDevice (" << id
-		    << ") for FaultInput (" << (*it).second->id << ")";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Failed to find DigitalDevice/AnalogDevice (" << id
+        << ") for FaultInput (" << (*it).second->id << ")";
+  throw(DbException(errorStream.str()));
       }
       // Found the DbAnalogDevice, configure it
       else {
-	(*it).second->analogDevice = (*aDeviceIt).second;
+  (*it).second->analogDevice = (*aDeviceIt).second;
 
-	if ((*aDeviceIt).second->evaluation == FAST_EVALUATION) {
-	  LOG_TRACE("DATABASE", "AnalogDevice " << (*aDeviceIt).second->name
-		    << ": Fast Evaluation");
-	  DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
-	  if (faultIt == faults->end()) {
-	    errorStream << "ERROR: Failed to find Fault (" << id
-			<< ") for FaultInput (" << (*it).second->id << ")";
-	    throw(DbException(errorStream.str()));
-	  }
-	  else {
-	    if (!(*faultIt).second->faultStates) {
-	      errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
-			  << ") for FaultInput (" << (*it).second->id << ")";
-	      throw(DbException(errorStream.str()));
-	    }
+  if ((*aDeviceIt).second->evaluation == FAST_EVALUATION) {
+    LOG_TRACE("DATABASE", "AnalogDevice " << (*aDeviceIt).second->name
+        << ": Fast Evaluation");
+    DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
+    if (faultIt == faults->end()) {
+      errorStream << "ERROR: Failed to find Fault (" << id
+      << ") for FaultInput (" << (*it).second->id << ")";
+      throw(DbException(errorStream.str()));
+    }
+    else {
+      if (!(*faultIt).second->faultStates) {
+        errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
+        << ") for FaultInput (" << (*it).second->id << ")";
+        throw(DbException(errorStream.str()));
+      }
 
-	    // There is one DbFaultState per threshold bit, for BPMs there are
-	    // 24 bits (8 for X, 8 for Y and 8 for TMIT). Other analog devices
-	    // have up to 32 bits (4 integrators) - there is one destination mask
-	    // per integrator
+      // There is one DbFaultState per threshold bit, for BPMs there are
+      // 24 bits (8 for X, 8 for Y and 8 for TMIT). Other analog devices
+      // have up to 32 bits (4 integrators) - there is one destination mask
+      // per integrator
 
-	    // There is a unique power class for each threshold bit (each DbFaultState)
-	    // The destination masks for the thresholds for the same integrator
-	    // must be and'ed together.
+      // There is a unique power class for each threshold bit (each DbFaultState)
+      // The destination masks for the thresholds for the same integrator
+      // must be and'ed together.
 
-	    // Go through the DbFaultStates for this DbFault, i.e. the individual threshold bits
-	    for (DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
-		 faultState != (*faultIt).second->faultStates->end(); ++faultState) {
-	      // The DbDeviceState value defines which integrator the fault belongs to.
-	      // Bits 0 through 7 are for the first integrator, 8 through 15 for the second,
-	      // and so on.
-	      uint32_t value = (*faultState).second->deviceState->value;
-	      int integratorIndex = 4;
+      // Go through the DbFaultStates for this DbFault, i.e. the individual threshold bits
+      for (DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
+     faultState != (*faultIt).second->faultStates->end(); ++faultState) {
+        // The DbDeviceState value defines which integrator the fault belongs to.
+        // Bits 0 through 7 are for the first integrator, 8 through 15 for the second,
+        // and so on.
+        uint32_t value = (*faultState).second->deviceState->value;
+        int integratorIndex = 4;
 
-	      if (value & 0x000000FF) integratorIndex = 0;
-	      if (value & 0x0000FF00) integratorIndex = 1;
-	      if (value & 0x00FF0000) integratorIndex = 2;
-	      if (value & 0xFF000000) integratorIndex = 3;
+        if (value & 0x000000FF) integratorIndex = 0;
+        if (value & 0x0000FF00) integratorIndex = 1;
+        if (value & 0x00FF0000) integratorIndex = 2;
+        if (value & 0xFF000000) integratorIndex = 3;
 
-	      if (integratorIndex >= 4) {
-		errorStream << "ERROR: Invalid deviceState value Fault (" << (*faultIt).second->id
-			    << "), FaultInput (" << (*it).second->id << "), DeviceState ("
-			    << (*faultState).second->deviceState->id << "), value=0x"
-			    << std::hex << (*faultState).second->deviceState->value << std::dec;
-		throw(DbException(errorStream.str()));
-	      }
+        if (integratorIndex >= 4) {
+    errorStream << "ERROR: Invalid deviceState value Fault (" << (*faultIt).second->id
+          << "), FaultInput (" << (*it).second->id << "), DeviceState ("
+          << (*faultState).second->deviceState->id << "), value=0x"
+          << std::hex << (*faultState).second->deviceState->value << std::dec;
+    throw(DbException(errorStream.str()));
+        }
 
-	      uint32_t thresholdIndex = 0;
-	      bool isSet = false;
-	      while (!isSet) {
-		if (value & 0x01) {
-		  isSet = true;
-		}
-		else {
-		  thresholdIndex++;
-		  value >>= 1;
-		}
-		if (thresholdIndex >= sizeof(uint32_t) * 8) {
-		  errorStream << "ERROR: Invalid threshold bit for Fault (" << (*faultIt).second->id
-			      << "), FaultInput (" << (*it).second->id << "), DeviceState ("
-			      << (*faultState).second->deviceState->id << ")";
-		  throw(DbException(errorStream.str()));
-		}
-	      }
+        uint32_t thresholdIndex = 0;
+        bool isSet = false;
+        while (!isSet) {
+    if (value & 0x01) {
+      isSet = true;
+    }
+    else {
+      thresholdIndex++;
+      value >>= 1;
+    }
+    if (thresholdIndex >= sizeof(uint32_t) * 8) {
+      errorStream << "ERROR: Invalid threshold bit for Fault (" << (*faultIt).second->id
+            << "), FaultInput (" << (*it).second->id << "), DeviceState ("
+            << (*faultState).second->deviceState->id << ")";
+      throw(DbException(errorStream.str()));
+    }
+        }
 
-	      // Find the power classes for analog thresholds based on the AllowedClasses.
-	      // Note: even though the database allows for different power classes for
-	      // different destinations for the same fault, the firmware only has a single
-	      // power class to apply for a 16-bit destination mask. For example:
-	      // IM01B Charge Fault has one AllowedClass per destination, where
-	      //   Shutter = power class 1 (destination 1)
-	      //   AOM = power class 0 (destination 2)
-	      // The power class for the destination mask 0x03 is power class 0 (the lowest)
-	      for (DbAllowedClassMap::iterator allowedClass =
-		     (*faultState).second->allowedClasses->begin();
-		   allowedClass != (*faultState).second->allowedClasses->end(); ++allowedClass) {
-		(*aDeviceIt).second->fastDestinationMask[integratorIndex] |=
-		  (*allowedClass).second->beamDestination->destinationMask;
-		LOG_TRACE("DATABASE", "PowerClass: integrator=" << integratorIndex
-			  << " threshold index=" << thresholdIndex
-			  << " current power=" << (*aDeviceIt).second->fastPowerClass[thresholdIndex]
-			  << " power=" << (*allowedClass).second->beamClass->number
-			  << " allowedClassId=" << (*allowedClass).second->id
-			  << " destinationMask=0x" << std::hex << (*allowedClass).second->beamDestination->destinationMask << std::dec );
-		if ((*aDeviceIt).second->fastPowerClassInit[thresholdIndex] == 1) {
-		  (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
-		    (*allowedClass).second->beamClass->number;
-		  (*aDeviceIt).second->fastPowerClassInit[thresholdIndex] = 0;
-		}
-		else {
-		  if ((*allowedClass).second->beamClass->number <
-		      (*aDeviceIt).second->fastPowerClass[thresholdIndex]) {
-		    (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
-		      (*allowedClass).second->beamClass->number;
-		  }
-		}
-	      }
-	    }
-	  }
-	}
+        // Find the power classes for analog thresholds based on the AllowedClasses.
+        // Note: even though the database allows for different power classes for
+        // different destinations for the same fault, the firmware only has a single
+        // power class to apply for a 16-bit destination mask. For example:
+        // IM01B Charge Fault has one AllowedClass per destination, where
+        //   Shutter = power class 1 (destination 1)
+        //   AOM = power class 0 (destination 2)
+        // The power class for the destination mask 0x03 is power class 0 (the lowest)
+        for (DbAllowedClassMap::iterator allowedClass =
+         (*faultState).second->allowedClasses->begin();
+       allowedClass != (*faultState).second->allowedClasses->end(); ++allowedClass) {
+    (*aDeviceIt).second->fastDestinationMask[integratorIndex] |=
+      (*allowedClass).second->beamDestination->destinationMask;
+    LOG_TRACE("DATABASE", "PowerClass: integrator=" << integratorIndex
+        << " threshold index=" << thresholdIndex
+        << " current power=" << (*aDeviceIt).second->fastPowerClass[thresholdIndex]
+        << " power=" << (*allowedClass).second->beamClass->number
+        << " allowedClassId=" << (*allowedClass).second->id
+        << " destinationMask=0x" << std::hex << (*allowedClass).second->beamDestination->destinationMask << std::dec );
+    if ((*aDeviceIt).second->fastPowerClassInit[thresholdIndex] == 1) {
+      (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
+        (*allowedClass).second->beamClass->number;
+      (*aDeviceIt).second->fastPowerClassInit[thresholdIndex] = 0;
+    }
+    else {
+      if ((*allowedClass).second->beamClass->number <
+          (*aDeviceIt).second->fastPowerClass[thresholdIndex]) {
+        (*aDeviceIt).second->fastPowerClass[thresholdIndex] =
+          (*allowedClass).second->beamClass->number;
+      }
+    }
+        }
+      }
+    }
+  }
       }
     }
     else {
@@ -465,46 +465,46 @@ void MpsDb::configureFaultInputs() {
       // If the DbDigitalDevice is set for fast evaluation, save a pointer to the
       // DbFaultInput
       if ((*deviceIt).second->evaluation == FAST_EVALUATION) {
-	DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
-	if (faultIt == faults->end()) {
-	  errorStream << "ERROR: Failed to find Fault (" << id
-		      << ") for FaultInput (" << (*it).second->id << ")";
-	  throw(DbException(errorStream.str()));
-	}
-	else {
-	  if (!(*faultIt).second->faultStates) {
-	    errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
-			<< ") for FaultInput (" << (*it).second->id << ")";
-	    throw(DbException(errorStream.str()));
-	  }
-	  (*deviceIt).second->fastDestinationMask = 0;
-	  (*deviceIt).second->fastPowerClass = 100;
-	  (*deviceIt).second->fastExpectedState = 0;
+  DbFaultMap::iterator faultIt = faults->find((*it).second->faultId);
+  if (faultIt == faults->end()) {
+    errorStream << "ERROR: Failed to find Fault (" << id
+          << ") for FaultInput (" << (*it).second->id << ")";
+    throw(DbException(errorStream.str()));
+  }
+  else {
+    if (!(*faultIt).second->faultStates) {
+      errorStream << "ERROR: No FaultStates found for Fault (" << (*faultIt).second->id
+      << ") for FaultInput (" << (*it).second->id << ")";
+      throw(DbException(errorStream.str()));
+    }
+    (*deviceIt).second->fastDestinationMask = 0;
+    (*deviceIt).second->fastPowerClass = 100;
+    (*deviceIt).second->fastExpectedState = 0;
 
-	  if ((*faultIt).second->faultStates->size() != 1) {
-	    errorStream << "ERROR: DigitalDevice configured with FAST evaluation must have one fault state only."
-			<< " Found " << (*faultIt).second->faultStates->size() << " fault states for "
-			<< "device " << (*deviceIt).second->name;
-	    throw(DbException(errorStream.str()));
-	  }
-	  DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
+    if ((*faultIt).second->faultStates->size() != 1) {
+      errorStream << "ERROR: DigitalDevice configured with FAST evaluation must have one fault state only."
+      << " Found " << (*faultIt).second->faultStates->size() << " fault states for "
+      << "device " << (*deviceIt).second->name;
+      throw(DbException(errorStream.str()));
+    }
+    DbFaultStateMap::iterator faultState = (*faultIt).second->faultStates->begin();
 
-	  // Set the expected state as the oposite of the expected faulted value
-	  // For example a faulted fast valve sets the digital input to high (0V, digital 0),
-	  // the expected normal state is 1.
-	  if (!(*faultState).second->deviceState->value) {
-	    (*deviceIt).second->fastExpectedState = 1;
-	  }
+    // Set the expected state as the oposite of the expected faulted value
+    // For example a faulted fast valve sets the digital input to high (0V, digital 0),
+    // the expected normal state is 1.
+    if (!(*faultState).second->deviceState->value) {
+      (*deviceIt).second->fastExpectedState = 1;
+    }
 
-	  //	  DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
-	  for (DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
-	       allowedClass != (*faultState).second->allowedClasses->end(); ++allowedClass) {
-	    (*deviceIt).second->fastDestinationMask |= (*allowedClass).second->beamDestination->destinationMask;
-	    if ((*allowedClass).second->beamClass->number < (*deviceIt).second->fastPowerClass) {
-	      (*deviceIt).second->fastPowerClass = (*allowedClass).second->beamClass->number;
-	    }
-	  }
-	}
+    //    DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
+    for (DbAllowedClassMap::iterator allowedClass = (*faultState).second->allowedClasses->begin();
+         allowedClass != (*faultState).second->allowedClasses->end(); ++allowedClass) {
+      (*deviceIt).second->fastDestinationMask |= (*allowedClass).second->beamDestination->destinationMask;
+      if ((*allowedClass).second->beamClass->number < (*deviceIt).second->fastPowerClass) {
+        (*deviceIt).second->fastPowerClass = (*allowedClass).second->beamClass->number;
+      }
+    }
+  }
       }
     }
   }
@@ -518,7 +518,7 @@ void MpsDb::configureFaultInputs() {
     DbFaultMap::iterator faultIt = faults->find(id);
     if (faultIt == faults->end()) {
       errorStream <<  "ERROR: Failed to configure database, invalid ID found for Fault ("
-		  << id << ") for FaultInput (" << (*it).second->id << ")";
+      << id << ") for FaultInput (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
 
@@ -528,7 +528,7 @@ void MpsDb::configureFaultInputs() {
       (*faultIt).second->faultInputs = DbFaultInputMapPtr(faultInputs);
     }
     (*faultIt).second->faultInputs->insert(std::pair<int, DbFaultInputPtr>((*it).second->id,
-									   (*it).second));
+                     (*it).second));
   }
 
   //  std::cout << "assign evaluation" << std::endl;
@@ -541,22 +541,22 @@ void MpsDb::configureFaultInputs() {
     bool slowEvaluation = false;
     if (!(*faultIt).second->faultInputs) {
       errorStream << "ERROR: Missing faultInputs map for Fault \""
-		  << (*faultIt).second->name << "\": "
-		  << (*faultIt).second->description;
+      << (*faultIt).second->name << "\": "
+      << (*faultIt).second->description;
       throw(DbException(errorStream.str()));
     }
 
     for (DbFaultInputMap::iterator inputIt = (*faultIt).second->faultInputs->begin();
-	 inputIt != (*faultIt).second->faultInputs->end(); ++inputIt) {
+   inputIt != (*faultIt).second->faultInputs->end(); ++inputIt) {
       if ((*inputIt).second->analogDevice) {
-	if ((*inputIt).second->analogDevice->evaluation == SLOW_EVALUATION) {
-	  slowEvaluation = true;
-	}
+  if ((*inputIt).second->analogDevice->evaluation == SLOW_EVALUATION) {
+    slowEvaluation = true;
+  }
       }
       else if ((*inputIt).second->digitalDevice) {
-	if ((*inputIt).second->digitalDevice->evaluation == SLOW_EVALUATION) {
-	  slowEvaluation = true;
-	}
+  if ((*inputIt).second->digitalDevice->evaluation == SLOW_EVALUATION) {
+    slowEvaluation = true;
+  }
       }
     }
     if (slowEvaluation) {
@@ -581,7 +581,7 @@ void MpsDb::configureFaultStates() {
     DbFaultMap::iterator faultIt = faults->find(id);
     if (faultIt == faults->end()) {
       errorStream << "ERROR: Failed to configure database, invalid ID found for Fault ("
-		  << id << ") for FaultState (" << (*it).second->id << ")";
+      << id << ") for FaultState (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
 
@@ -591,10 +591,10 @@ void MpsDb::configureFaultStates() {
       (*faultIt).second->faultStates = DbFaultStateMapPtr(digFaultStates);
     }
     (*faultIt).second->faultStates->insert(std::pair<int, DbFaultStatePtr>((*it).second->id,
-											 (*it).second));
+                       (*it).second));
     LOG_TRACE("DATABASE", "Adding FaultState (" << (*it).second->id << ") to "
-	      " Fault (" << (*faultIt).second->id << ", " << (*faultIt).second->name
-	      << ", " << (*faultIt).second->description << ")");
+        " Fault (" << (*faultIt).second->id << ", " << (*faultIt).second->name
+        << ", " << (*faultIt).second->description << ")");
 
     // If this DigitalFault is the default, then assign it to the fault:
     if ((*it).second->defaultState && !((*faultIt).second->defaultFaultState)) {
@@ -606,7 +606,7 @@ void MpsDb::configureFaultStates() {
     DbDeviceStateMap::iterator deviceStateIt = deviceStates->find(id);
     if (deviceStateIt == deviceStates->end()) {
       errorStream << "ERROR: Failed to configure database, invalid ID found for DeviceState ("
-		  << id << ") for FaultState (" << (*it).second->id << ")";
+      << id << ") for FaultState (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
     (*it).second->deviceState = (*deviceStateIt).second;
@@ -618,8 +618,8 @@ void MpsDb::configureFaultStates() {
        fault != faults->end(); ++fault) {
     if (!(*fault).second->faultStates) {
       errorStream << "ERROR: Fault " << (*fault).second->name << " ("
-		  << (*fault).second->description << ", id="
-		  << (*fault).second->id << ") has no FaultStates";
+      << (*fault).second->description << ", id="
+      << (*fault).second->id << ") has no FaultStates";
       throw(DbException(errorStream.str()));
     }
   }
@@ -639,7 +639,7 @@ void MpsDb::configureAnalogDevices() {
     }
     else {
       errorStream << "ERROR: Failed to configure database, invalid deviceTypeId ("
-		  << typeId << ") for AnalogDevice (" <<  (*it).second->id << ")";
+      << typeId << ") for AnalogDevice (" <<  (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
 
@@ -647,7 +647,7 @@ void MpsDb::configureAnalogDevices() {
     DbChannelMap::iterator channelIt = analogChannels->find(channelId);
     if (channelIt == analogChannels->end()) {
       errorStream << "ERROR: Failed to configure database, invalid ID found for Channel ("
-		  << channelId << ") for AnalogDevice (" << (*it).second->id << ")";
+      << channelId << ") for AnalogDevice (" << (*it).second->id << ")";
       throw(DbException(errorStream.str()));
     }
     (*it).second->channel = (*channelIt).second;
@@ -668,15 +668,15 @@ void MpsDb::configureIgnoreConditions() {
     if (condition != conditions->end()) {
       // Create a map to hold IgnoreConditions
       if (!(*condition).second->ignoreConditions) {
-	DbIgnoreConditionMap *ignoreConditionMap = new DbIgnoreConditionMap();
-	(*condition).second->ignoreConditions = DbIgnoreConditionMapPtr(ignoreConditionMap);
+  DbIgnoreConditionMap *ignoreConditionMap = new DbIgnoreConditionMap();
+  (*condition).second->ignoreConditions = DbIgnoreConditionMapPtr(ignoreConditionMap);
       }
       (*condition).second->ignoreConditions->
-	insert(std::pair<int, DbIgnoreConditionPtr>((*ignoreCondition).second->id, (*ignoreCondition).second));
+  insert(std::pair<int, DbIgnoreConditionPtr>((*ignoreCondition).second->id, (*ignoreCondition).second));
     }
     else {
       errorStream << "ERROR: Failed to configure database, invalid conditionId ("
-		  << conditionId << ") for ignoreCondition (" <<  (*ignoreCondition).second->id << ")";
+      << conditionId << ") for ignoreCondition (" <<  (*ignoreCondition).second->id << ")";
       throw(DbException(errorStream.str()));
     }
 
@@ -687,12 +687,12 @@ void MpsDb::configureIgnoreConditions() {
     if (faultStateId != DbIgnoreCondition::INVALID_ID) {
       DbFaultStateMap::iterator faultIt = faultStates->find(faultStateId);
       if (faultIt != faultStates->end()) {
-	(*ignoreCondition).second->faultState = (*faultIt).second;
+  (*ignoreCondition).second->faultState = (*faultIt).second;
       }
       else {
-	errorStream << "ERROR: Failed to configure database, invalid ID for FaultState ("
-		    << faultStateId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Failed to configure database, invalid ID for FaultState ("
+        << faultStateId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+  throw(DbException(errorStream.str()));
       }
     }
 
@@ -702,19 +702,19 @@ void MpsDb::configureIgnoreConditions() {
     if (analogDeviceId != DbIgnoreCondition::INVALID_ID) {
       DbAnalogDeviceMap::iterator deviceIt = analogDevices->find(analogDeviceId);
       if (deviceIt != analogDevices->end()) {
-	(*ignoreCondition).second->analogDevice = (*deviceIt).second;
+  (*ignoreCondition).second->analogDevice = (*deviceIt).second;
       }
       else {
-	errorStream << "ERROR: Failed to configure database, invalid ID for AnalogDevice ("
-		    << analogDeviceId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Failed to configure database, invalid ID for AnalogDevice ("
+        << analogDeviceId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+  throw(DbException(errorStream.str()));
       }
     }
     else {
       if (faultStateId == DbIgnoreCondition::INVALID_ID) {
-	errorStream << "ERROR: Failed to configure database, invalid ID for FaultState and"
-		    << " FaultState for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Failed to configure database, invalid ID for FaultState and"
+        << " FaultState for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+  throw(DbException(errorStream.str()));
       }
     }
   }
@@ -728,15 +728,15 @@ void MpsDb::configureIgnoreConditions() {
     if (condition != conditions->end()) {
       // Create a map to hold ConditionInputs
       if (!(*condition).second->conditionInputs) {
-	DbConditionInputMap *conditionInputMap = new DbConditionInputMap();
-	(*condition).second->conditionInputs = DbConditionInputMapPtr(conditionInputMap);
+  DbConditionInputMap *conditionInputMap = new DbConditionInputMap();
+  (*condition).second->conditionInputs = DbConditionInputMapPtr(conditionInputMap);
       }
       (*condition).second->conditionInputs->
-	insert(std::pair<int, DbConditionInputPtr>((*conditionInput).second->id, (*conditionInput).second));
+  insert(std::pair<int, DbConditionInputPtr>((*conditionInput).second->id, (*conditionInput).second));
     }
     else {
       errorStream << "ERROR: Failed to configure database, invalid conditionId ("
-		  << conditionId << ") for conditionInput (" <<  (*conditionInput).second->id << ")";
+      << conditionId << ") for conditionInput (" <<  (*conditionInput).second->id << ")";
       throw(DbException(errorStream.str()));
     }
 
@@ -748,7 +748,7 @@ void MpsDb::configureIgnoreConditions() {
     }
     else {
       errorStream << "ERROR: Failed to configure database, invalid ID found of FaultState ("
-		  << faultStateId << ") for ConditionInput (" <<  (*conditionInput).second->id << ")";
+      << faultStateId << ") for ConditionInput (" <<  (*conditionInput).second->id << ")";
       throw(DbException(errorStream.str()));
     }
   }
@@ -817,8 +817,8 @@ void MpsDb::configureApplicationCards() {
       aPtr = (*applicationCardIt).second;
       // Alloc a new map for digital devices if one is not there yet
       if (!aPtr->digitalDevices) {
-	DbDigitalDeviceMap *digitalDevices = new DbDigitalDeviceMap();
-	aPtr->digitalDevices = DbDigitalDeviceMapPtr(digitalDevices);
+  DbDigitalDeviceMap *digitalDevices = new DbDigitalDeviceMap();
+  aPtr->digitalDevices = DbDigitalDeviceMapPtr(digitalDevices);
       }
       // Once the map is there, add the digital device
       aPtr->digitalDevices->insert(std::pair<int, DbDigitalDevicePtr>(dPtr->id, dPtr));
@@ -838,14 +838,14 @@ void MpsDb::configureApplicationCards() {
       aPtr = (*applicationCardIt).second;
       // Alloc a new map for analog devices if one is not there yet
       if (aPtr->digitalDevices) {
-	errorStream << "ERROR: Found ApplicationCard with digital AND analog devices,"
-		    << " can't handle that (cardId="
-		    << (*analogDeviceIt).second->cardId << ")";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Found ApplicationCard with digital AND analog devices,"
+        << " can't handle that (cardId="
+        << (*analogDeviceIt).second->cardId << ")";
+  throw(DbException(errorStream.str()));
       }
       if (!aPtr->analogDevices) {
-	DbAnalogDeviceMap *analogDevices = new DbAnalogDeviceMap();
-	aPtr->analogDevices = DbAnalogDeviceMapPtr(analogDevices);
+  DbAnalogDeviceMap *analogDevices = new DbAnalogDeviceMap();
+  aPtr->analogDevices = DbAnalogDeviceMapPtr(analogDevices);
       }
       // Once the map is there, add the analog device
       aPtr->analogDevices->insert(std::pair<int, DbAnalogDevicePtr>(adPtr->id, adPtr));
@@ -905,12 +905,12 @@ void MpsDb::forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassI
     if (beamClassId != CLEAR_BEAM_CLASS) {
       DbBeamClassMap::iterator beamClassIt = beamClasses->find(beamClassId);
       if (beamClassIt != beamClasses->end()) {
-	(*beamDestIt).second->setForceBeamClass((*beamClassIt).second);
-	std::cout << "Force dest["<< beamDestinationId <<"] to class [" << beamClassId << "]" << std::endl;
+  (*beamDestIt).second->setForceBeamClass((*beamClassIt).second);
+  std::cout << "Force dest["<< beamDestinationId <<"] to class [" << beamClassId << "]" << std::endl;
       }
       else {
-	(*beamDestIt).second->resetForceBeamClass();
-	std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
+  (*beamDestIt).second->resetForceBeamClass();
+  std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
       }
     }
     else {
@@ -928,8 +928,8 @@ void MpsDb::writeFirmwareConfiguration(bool forceAomAllow) {
        card != applicationCards->end(); ++card) {
     (*card).second->writeConfiguration(forceAomAllow);
     Firmware::getInstance().writeConfig((*card).second->globalId, fastConfigurationBuffer +
-					(*card).second->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES,
-					APPLICATION_CONFIG_BUFFER_USED_SIZE_BYTES);
+          (*card).second->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES,
+          APPLICATION_CONFIG_BUFFER_USED_SIZE_BYTES);
     i++;
   }
 
@@ -979,7 +979,7 @@ int MpsDb::load(std::string yamlFileName) {
     throw(DbException(errorStream.str()));
   } catch (...) {
     errorStream << "ERROR: Failed to load YAML file ("
-		<< yamlFileName << ")";
+    << yamlFileName << ")";
     throw(DbException(errorStream.str()));
   }
 
@@ -990,7 +990,7 @@ int MpsDb::load(std::string yamlFileName) {
     size_t found = s.find(":");
     if (found == std::string::npos) {
       errorStream << "ERROR: Can't find Node name in YAML file ("
-		  << yamlFileName << ")";
+      << yamlFileName << ")";
       throw(DbException(errorStream.str()));
     }
     std::string nodeName = s.substr(0, found);
@@ -1043,9 +1043,9 @@ int MpsDb::load(std::string yamlFileName) {
       // Do not raise exception if the YAML node is known, but
       // does not need to be loaded by central node engine
       if (nodeName != "LinkNode") {
-	errorStream << "ERROR: Unknown YAML node name ("
-		    << nodeName << ")";
-	throw(DbException(errorStream.str()));
+  errorStream << "ERROR: Unknown YAML node name ("
+        << nodeName << ")";
+  throw(DbException(errorStream.str()));
       }
     }
   }
@@ -1097,56 +1097,56 @@ void MpsDb::showFault(DbFaultPtr fault) {
   }
   else {
     for (DbFaultInputMap::iterator input = fault->faultInputs->begin();
-	 input != fault->faultInputs->end(); ++input) {
+   input != fault->faultInputs->end(); ++input) {
       int deviceId = (*input).second->deviceId;
       DbDigitalDeviceMap::iterator digitalDevice = digitalDevices->find(deviceId);
       if (digitalDevice == digitalDevices->end()) {
-	// If no inputs, then this could be an analog device
-	DbAnalogDeviceMap::iterator analogDevice = analogDevices->find(deviceId);
-	if (analogDevice == analogDevices->end()) {
-	  std::cout << "| - WARNING: No digital/analog devices for this fault!";
-	}
-	else {
-	  std::cout << "| - Input[" << (*analogDevice).second->name
-		    << "], Bypass[";
-	  if (!(*analogDevice).second->bypass) {
-	    std::cout << "WARNING: NO BYPASS INFO]";
-	  }
-	  else {
-	    for (uint32_t i = 0; i < ANALOG_DEVICE_NUM_THRESHOLDS; ++i) {
-	      if ((*analogDevice).second->bypass[i]->status == BYPASS_VALID) {
-		std::cout << "V";
-	      }
-	      else {
-		std::cout << "E";
-	      }
-	    }
-	    std::cout << "]";
-	  }
-	  std::cout << std::endl;
-	}
+  // If no inputs, then this could be an analog device
+  DbAnalogDeviceMap::iterator analogDevice = analogDevices->find(deviceId);
+  if (analogDevice == analogDevices->end()) {
+    std::cout << "| - WARNING: No digital/analog devices for this fault!";
+  }
+  else {
+    std::cout << "| - Input[" << (*analogDevice).second->name
+        << "], Bypass[";
+    if (!(*analogDevice).second->bypass) {
+      std::cout << "WARNING: NO BYPASS INFO]";
+    }
+    else {
+      for (uint32_t i = 0; i < ANALOG_DEVICE_NUM_THRESHOLDS; ++i) {
+        if ((*analogDevice).second->bypass[i]->status == BYPASS_VALID) {
+    std::cout << "V";
+        }
+        else {
+    std::cout << "E";
+        }
+      }
+      std::cout << "]";
+    }
+    std::cout << std::endl;
+  }
       }
       else {
-	for (DbDeviceInputMap::iterator devInput =
-	       (*digitalDevice).second->inputDevices->begin();
-	     devInput != (*digitalDevice).second->inputDevices->end(); ++devInput) {
-	  std::cout << "| - Input[" << (*devInput).second->id
-		    << "], Position[" << (*devInput).second->bitPosition
-		    << "], Bypass[";
+  for (DbDeviceInputMap::iterator devInput =
+         (*digitalDevice).second->inputDevices->begin();
+       devInput != (*digitalDevice).second->inputDevices->end(); ++devInput) {
+    std::cout << "| - Input[" << (*devInput).second->id
+        << "], Position[" << (*devInput).second->bitPosition
+        << "], Bypass[";
 
-	  if (!(*devInput).second->bypass) {
-	    std::cout << "WARNING: NO BYPASS INFO]";
-	  }
-	  else {
-	    if ((*devInput).second->bypass->status == BYPASS_VALID) {
-	      std::cout << "VALID]";
-	    }
-	    else {
-	      std::cout << "EXPIRED]";
-	    }
-	  }
-	  std::cout << std::endl;
-	}
+    if (!(*devInput).second->bypass) {
+      std::cout << "WARNING: NO BYPASS INFO]";
+    }
+    else {
+      if ((*devInput).second->bypass->status == BYPASS_VALID) {
+        std::cout << "VALID]";
+      }
+      else {
+        std::cout << "EXPIRED]";
+      }
+    }
+    std::cout << std::endl;
+  }
       }
     }
   }
@@ -1354,30 +1354,30 @@ void MpsDb::fwUpdateReader()
         }
 
 
-	uint32_t expected_size = APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES +
-	  NUM_APPLICATIONS *
-	  APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES;
-	uint32_t received_size = 0;
+  uint32_t expected_size = APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES +
+    NUM_APPLICATIONS *
+    APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES;
+  uint32_t received_size = 0;
 
-	while (received_size != expected_size)
-	  {
-	    received_size = Firmware::getInstance().readUpdateStream(fwUpdateBuffer.getWritePtr()->data(),
-								     expected_size, _inputUpdateTimeout);
+  while (received_size != expected_size)
+    {
+      received_size = Firmware::getInstance().readUpdateStream(fwUpdateBuffer.getWritePtr()->data(),
+                     expected_size, _inputUpdateTimeout);
 #ifndef FW_ENABLED
-	    if (!run) {
-	      std::cout << "FW Update Data reader interrupted" << std::endl;
-	      return;
-	    }
+      if (!run) {
+        std::cout << "FW Update Data reader interrupted" << std::endl;
+        return;
+      }
 #endif
-	    if (received_size == 0)
-	      {
-		++_updateTimeoutCounter;
-	      }
-	  }
+      if (received_size == 0)
+        {
+    ++_updateTimeoutCounter;
+        }
+    }
 
         fwUpdateBuffer.doneWriting();
         fwUpdateTimer.tick();
-	fwUpdateTimer.start();
+  fwUpdateTimer.start();
     }
 }
 

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -194,8 +194,8 @@ void MpsDb::updateInputs()
         {
             std::lock_guard<std::mutex> lock(inputsUpdatedMutex);
             inputsUpdated = true;
-            inputsUpdatedCondVar.notify_all();
         }
+        inputsUpdatedCondVar.notify_one();
     }
 }
 
@@ -1742,3 +1742,13 @@ void MpsDb::mitigationWriter()
 
     }
 }
+
+void MpsDb::inputProcessed()
+{
+    {
+        std::lock_guard<std::mutex> lock(inputsUpdatedMutex);
+        inputsUpdated = false;
+    }
+    inputsUpdatedCondVar.notify_one();
+};
+

--- a/src/central_node_database.h
+++ b/src/central_node_database.h
@@ -190,7 +190,7 @@ class MpsDb {
   bool                     isInputReady()          const { return inputsUpdated;         };
   std::mutex*              getInputUpdateMutex()         { return &inputsUpdatedMutex;   };
   std::condition_variable* getInputUpdateCondVar()       { return &inputsUpdatedCondVar; };
-  void                     inputProcessed()              { inputsUpdated = false;        };
+  void                     inputProcessed();
 
   bool                     isMitBufferWriteReady() const { return softwareMitigationBuffer.isWriteReady(); };
   std::mutex*              getMitBufferMutex()           { return softwareMitigationBuffer.getMutex();     };

--- a/src/central_node_database.h
+++ b/src/central_node_database.h
@@ -14,7 +14,6 @@
 #include <stdint.h>
 #include <time_util.h>
 #include "timer.h"
-#include "buffer.h"
 #include "queue.h"
 
 #include <boost/shared_ptr.hpp>
@@ -58,8 +57,15 @@ class MpsDb {
   // uint8_t fastUpdateBuffer[APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES +
 		// 	   NUM_APPLICATIONS * APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES];
 
-  DataBuffer<uint8_t>     fwUpdateBuffer;
-  static const uint32_t          fwUpdateBuferSize = APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES + NUM_APPLICATIONS * APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES;
+
+  typedef std::vector<uint8_t>       update_buffer_t;
+  typedef Queue<update_buffer_t>     update_queue_t;
+
+  update_buffer_t fwUpdateBuffer;
+  update_queue_t  fwUpdateQueue;
+  std::mutex      fwUpdateBufferMutex;
+
+  static const uint32_t fwUpdateBuferSize = APPLICATION_UPDATE_BUFFER_HEADER_SIZE_BYTES + NUM_APPLICATIONS * APPLICATION_UPDATE_BUFFER_INPUTS_SIZE_BYTES;
 
   boost::atomic<bool>     run;
 

--- a/src/central_node_database.h
+++ b/src/central_node_database.h
@@ -15,6 +15,7 @@
 #include <time_util.h>
 #include "timer.h"
 #include "buffer.h"
+#include "queue.h"
 
 #include <boost/shared_ptr.hpp>
 #include <boost/atomic.hpp>
@@ -86,7 +87,13 @@ class MpsDb {
   /**
    * Each destination takes 4-bits for the allowed power class.
    */
-  DataBuffer<uint32_t> softwareMitigationBuffer;
+  // Convinient typedefs
+  typedef std::vector<uint32_t>   mit_buffer_t;
+  typedef Queue<mit_buffer_t>     mit_queue_t;
+  typedef mit_queue_t::value_type mit_buffer_ptr_t;
+
+  mit_buffer_t softwareMitigationBuffer;
+  mit_queue_t  softwareMitigationQueue;
 
   Timer<double> _inputUpdateTime;
   bool _clearUpdateTime;
@@ -192,10 +199,7 @@ class MpsDb {
   std::condition_variable* getInputUpdateCondVar()       { return &inputsUpdatedCondVar; };
   void                     inputProcessed();
 
-  bool                     isMitBufferWriteReady() const { return softwareMitigationBuffer.isWriteReady(); };
-  std::mutex*              getMitBufferMutex()           { return softwareMitigationBuffer.getMutex();     };
-  std::condition_variable* getMitBufferCondVar()         { return softwareMitigationBuffer.getCondVar();   };
-  void                     mitBufferDoneWriting()        { softwareMitigationBuffer.doneWriting();         };
+  void                     pushMitBuffer();
 
   template<class MapPtrType, class IteratorType>
     void printMap(std::ostream &os, MapPtrType map,

--- a/src/central_node_database_tables.cc
+++ b/src/central_node_database_tables.cc
@@ -317,7 +317,7 @@ std::ostream & operator<<(std::ostream &os, DbAnalogDevice * const analogDevice)
 
 DbApplicationCard::DbApplicationCard() {};
 
-void DbApplicationCard::setUpdateBufferPtr(DataBuffer<uint8_t>* p)
+void DbApplicationCard::setUpdateBufferPtr(std::vector<uint8_t>* p)
 {
     fwUpdateBuffer = p;
 
@@ -335,7 +335,7 @@ ApplicationUpdateBufferBitSetHalf* DbApplicationCard::getWasLowBuffer()
     if (!fwUpdateBuffer)
         return NULL;
 
-    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->getReadPtr()->at(wasLowBufferOffset));
+    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->at(wasLowBufferOffset));
 }
 
 ApplicationUpdateBufferBitSetHalf* DbApplicationCard::getWasHighBuffer()
@@ -343,7 +343,7 @@ ApplicationUpdateBufferBitSetHalf* DbApplicationCard::getWasHighBuffer()
     if (!fwUpdateBuffer)
         return NULL;
 
-    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->getReadPtr()->at(wasHighBufferOffset));
+    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->at(wasHighBufferOffset));
 }
 
 std::ostream & operator<<(std::ostream &os, DbApplicationCard * const appCard) {

--- a/src/central_node_database_tables.h
+++ b/src/central_node_database_tables.h
@@ -14,8 +14,6 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include "buffer.h"
-
 /**
  * DbException class
  *
@@ -137,15 +135,15 @@ class DbApplicationCardInput {
   ApplicationUpdateBufferBitSetHalf* getWasLowBuffer();
   ApplicationUpdateBufferBitSetHalf* getWasHighBuffer();
 
-  void setUpdateBuffers(DataBuffer<uint8_t>* bufPtr, const size_t wasLowBufferOff, const size_t wasHighBufferOff);
+  void setUpdateBuffers(std::vector<uint8_t>* bufPtr, const size_t wasLowBufferOff, const size_t wasHighBufferOff);
 
   uint32_t getWasLow(int channel);
   uint32_t getWasHigh(int channel);
 
  private:
-  DataBuffer<uint8_t>* fwUpdateBuffer;
-  size_t               wasLowBufferOffset;
-  size_t               wasHighBufferOffset;
+  std::vector<uint8_t>* fwUpdateBuffer;
+  size_t                wasLowBufferOffset;
+  size_t                wasHighBufferOffset;
 };
 
 /**
@@ -384,7 +382,7 @@ class DbApplicationCard : public DbEntry {
   DbAnalogDeviceMapPtr analogDevices;
   DbDigitalDeviceMapPtr digitalDevices;
 
-  void setUpdateBufferPtr(DataBuffer<uint8_t>* p);
+  void setUpdateBufferPtr(std::vector<uint8_t>* p);
   ApplicationUpdateBufferBitSetHalf* getWasLowBuffer();
   ApplicationUpdateBufferBitSetHalf* getWasHighBuffer();
 
@@ -404,9 +402,9 @@ class DbApplicationCard : public DbEntry {
   friend std::ostream & operator<<(std::ostream &os, DbApplicationCard * const appCard);
 
  private:
-  DataBuffer<uint8_t>* fwUpdateBuffer;
-  size_t               wasLowBufferOffset;
-  size_t               wasHighBufferOffset;
+  std::vector<uint8_t>* fwUpdateBuffer;
+  size_t                wasLowBufferOffset;
+  size_t                wasHighBufferOffset;
 };
 
 typedef boost::shared_ptr<DbApplicationCard> DbApplicationCardPtr;

--- a/src/central_node_database_tables.h
+++ b/src/central_node_database_tables.h
@@ -461,9 +461,10 @@ class DbBeamClass : public DbEntry {
   friend std::ostream & operator<<(std::ostream &os, DbBeamClass * const beamClass);
 };
 
-typedef boost::shared_ptr<DbBeamClass> DbBeamClassPtr;
+typedef boost::shared_ptr<DbBeamClass>     DbBeamClassPtr;
 typedef std::map<uint32_t, DbBeamClassPtr> DbBeamClassMap;
-typedef boost::shared_ptr<DbBeamClassMap> DbBeamClassMapPtr;
+typedef boost::shared_ptr<DbBeamClassMap>  DbBeamClassMapPtr;
+typedef std::vector<uint32_t>              DbMitBuffer;
 
 /**
  * DbBeamDestination YAML class
@@ -481,7 +482,7 @@ class DbBeamDestination : public DbEntry {
 
   // Memory location where the allowed beam class for this device
   // is written and sent to firmware
-  void    setSoftwareMitigationBuffer(DataBuffer<uint32_t>* bufPtr) { softwareMitigationBuffer = bufPtr; };
+  void    setSoftwareMitigationBuffer(DbMitBuffer* bufPtr) { softwareMitigationBuffer = bufPtr; }
   uint8_t softwareMitigationBufferIndex;
   uint8_t bitShift; // define if mitigation uses high/low 4-bits in the softwareMitigationBuffer
 
@@ -496,7 +497,7 @@ class DbBeamDestination : public DbEntry {
       allowedBeamClass = tentativeBeamClass;
     }
 
-    softwareMitigationBuffer->getWritePtr()->at(softwareMitigationBufferIndex) |= ((allowedBeamClass->number & 0xF) << bitShift);
+    softwareMitigationBuffer->at(softwareMitigationBufferIndex) |= ((allowedBeamClass->number & 0xF) << bitShift);
 
     if (previousAllowedBeamClass->number != allowedBeamClass->number) {
       History::getInstance().logMitigation(id, previousAllowedBeamClass->id, allowedBeamClass->id);
@@ -515,7 +516,7 @@ class DbBeamDestination : public DbEntry {
   friend std::ostream & operator<<(std::ostream &os, DbBeamDestination * const beamDestination);
 
  private:
-  DataBuffer<uint32_t>* softwareMitigationBuffer;
+  DbMitBuffer* softwareMitigationBuffer;
 };
 
 typedef boost::shared_ptr<DbBeamDestination> DbBeamDestinationPtr;

--- a/src/central_node_engine.cc
+++ b/src/central_node_engine.cc
@@ -151,9 +151,9 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
     if (_evaluate)
     {
         _evaluate = false;
-	engineLock.unlock();
+    engineLock.unlock();
         threadJoin();
-	engineLock.lock();
+    engineLock.lock();
     }
 
     _evaluate = false;
@@ -165,12 +165,12 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
       std::unique_lock<std::mutex> lock(*mpsDb->getMutex()); // the database mutex is static - is the same for all instances
 
       if (mpsDb->load(yamlFileName) != 0)
-	{
-	  _errorStream.str(std::string());
-	  _errorStream << "ERROR: Failed to load yaml database ("
-		       << yamlFileName << ")";
-	  throw(EngineException(_errorStream.str()));
-	}
+    {
+      _errorStream.str(std::string());
+      _errorStream << "ERROR: Failed to load yaml database ("
+               << yamlFileName << ")";
+      throw(EngineException(_errorStream.str()));
+    }
 
       LOG_TRACE("ENGINE", "YAML Database loaded from " << yamlFileName);
 
@@ -184,37 +184,37 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
       // Currently if the number of channels differ between the loaded
       // databases the central node engine must be restarted.
       if (!_bypassManager)
-	{
-	  _bypassManager = BypassManagerPtr(new BypassManager());
-	  _bypassManager->createBypassMap(mpsDb);
-	  _bypassManager->startBypassThread();
-	}
+    {
+      _bypassManager = BypassManagerPtr(new BypassManager());
+      _bypassManager->createBypassMap(mpsDb);
+      _bypassManager->startBypassThread();
+    }
 
       LOG_TRACE("ENGINE", "BypassManager created");
 
       try
-	{
-	  mpsDb->configure();
-	}
+    {
+      mpsDb->configure();
+    }
       catch (DbException &e)
-	{
-	  throw e;
-	}
+    {
+      throw e;
+    }
 
       LOG_TRACE("ENGINE", "MPS Database configured from YAML");
 
       // Assign bypass to each digital/analog input
       try
-	{
-	  _bypassManager->assignBypass(mpsDb);
-	}
+    {
+      _bypassManager->assignBypass(mpsDb);
+    }
       catch (CentralNodeException &e)
-	{
-	  _initialized = true;
-	  _evaluate = true;
-	  startUpdateThread();
-	  throw e;
-	}
+    {
+      _initialized = true;
+      _evaluate = true;
+      startUpdateThread();
+      throw e;
+    }
 
       // Now that the database has been loaded and configured
       // successfully, assign to _mpsDb shared_ptr
@@ -239,20 +239,20 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
       uint32_t num = 0;
       uint32_t lowNum = 100;
       for (DbBeamClassMap::iterator beamClass = _mpsDb->beamClasses->begin();
-	   beamClass != _mpsDb->beamClasses->end(); ++beamClass)
-	{
-	  if ((*beamClass).second->number > num)
-	    {
-	      _highestBeamClass = (*beamClass).second;
-	      num = (*beamClass).second->number;
-	    }
+       beamClass != _mpsDb->beamClasses->end(); ++beamClass)
+    {
+      if ((*beamClass).second->number > num)
+        {
+          _highestBeamClass = (*beamClass).second;
+          num = (*beamClass).second->number;
+        }
 
-	  if ((*beamClass).second->number < lowNum)
-	    {
-	      _lowestBeamClass = (*beamClass).second;
-	      lowNum = (*beamClass).second->number;
-	    }
-	}
+      if ((*beamClass).second->number < lowNum)
+        {
+          _lowestBeamClass = (*beamClass).second;
+          lowNum = (*beamClass).second->number;
+        }
+    }
 
       _mpsDb->writeFirmwareConfiguration();
     }
@@ -294,18 +294,18 @@ bool Engine::findShutterDevice()
        device != _mpsDb->digitalDevices->end(); ++device)
     {
       if ((*device).second->name == "Mech. Shutter")
-	{
-	  _shutterDevice = (*device).second;
-	  for (DbDeviceStateMap::iterator state = _shutterDevice->deviceType->deviceStates->begin();
-	       state != _shutterDevice->deviceType->deviceStates->end(); ++state)
-	    {
-	      if ((*state).second->name == "CLOSED")
-		{
-		  _shutterClosedStatus = (*state).second->value;
-		  return true;
-		}
-	    }
-	}
+    {
+      _shutterDevice = (*device).second;
+      for (DbDeviceStateMap::iterator state = _shutterDevice->deviceType->deviceStates->begin();
+           state != _shutterDevice->deviceType->deviceStates->end(); ++state)
+        {
+          if ((*state).second->name == "CLOSED")
+        {
+          _shutterClosedStatus = (*state).second->value;
+          return true;
+        }
+        }
+    }
     }
 
   return false;
@@ -352,7 +352,7 @@ bool Engine::setAllowedBeamClass()
       (*it).second->setAllowedBeamClass();
       //    (*it).second->allowedBeamClass = (*it).second->tentativeBeamClass;
       LOG_TRACE("ENGINE", (*it).second->name << " allowed class set to "
-		<< (*it).second->allowedBeamClass->number);
+        << (*it).second->allowedBeamClass->number);
     }
 
   return true;
@@ -519,7 +519,7 @@ void Engine::evaluateFaults()
     {
       // If device has no card assigned, then it cannot be evaluated.
       if ((*device).second->cardId != NO_CARD_ID &&
-	  (*device).second->evaluation != NO_EVALUATION) {
+      (*device).second->evaluation != NO_EVALUATION) {
         uint32_t deviceValue = 0;
         LOG_TRACE("ENGINE", "Getting inputs for " << (*device).second->name << " device"
             << ", there are " << (*device).second->inputDevices->size()
@@ -682,43 +682,43 @@ bool Engine::evaluateIgnoreConditions()
         (*condition).second->state = newConditionState;
         LOG_TRACE("ENGINE",  "Condition " << (*condition).second->name << " is " << (*condition).second->state);
 
-	if ((*condition).second->ignoreConditions) {
-	  for (DbIgnoreConditionMap::iterator ignoreCondition = (*condition).second->ignoreConditions->begin();
-	       ignoreCondition != (*condition).second->ignoreConditions->end(); ++ignoreCondition)
-	    {
-	      if ((*ignoreCondition).second->faultState)
-		{
-		  LOG_TRACE("ENGINE",  "Ignoring fault state [" << (*ignoreCondition).second->faultStateId << "]"
-			    << ", state=" << (*condition).second->state);
+    if ((*condition).second->ignoreConditions) {
+      for (DbIgnoreConditionMap::iterator ignoreCondition = (*condition).second->ignoreConditions->begin();
+           ignoreCondition != (*condition).second->ignoreConditions->end(); ++ignoreCondition)
+        {
+          if ((*ignoreCondition).second->faultState)
+        {
+          LOG_TRACE("ENGINE",  "Ignoring fault state [" << (*ignoreCondition).second->faultStateId << "]"
+                << ", state=" << (*condition).second->state);
 
-		  (*ignoreCondition).second->faultState->ignored = (*condition).second->state;
-		  // This check is needed in case specific faults from an AnalogDevice is
-		  // listed in the ignoreCondition.
-		  if ((*ignoreCondition).second->analogDevice) {
-		    int integrator = (*ignoreCondition).second->faultState->deviceState->getIntegrator();
-		    if ((*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] != (*condition).second->state) {
-		      reload = true; // reload configuration!
-		    }
-		    (*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] = (*condition).second->state;
-		  }
-		}
-	      else
-		{
-		  if ((*ignoreCondition).second->analogDevice)
-		    {
-		      LOG_TRACE("ENGINE",  "Ignoring analog device [" << (*ignoreCondition).second->analogDeviceId << "]"
-				<< ", state=" << (*condition).second->state);
+          (*ignoreCondition).second->faultState->ignored = (*condition).second->state;
+          // This check is needed in case specific faults from an AnalogDevice is
+          // listed in the ignoreCondition.
+          if ((*ignoreCondition).second->analogDevice) {
+            int integrator = (*ignoreCondition).second->faultState->deviceState->getIntegrator();
+            if ((*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] != (*condition).second->state) {
+              reload = true; // reload configuration!
+            }
+            (*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] = (*condition).second->state;
+          }
+        }
+          else
+        {
+          if ((*ignoreCondition).second->analogDevice)
+            {
+              LOG_TRACE("ENGINE",  "Ignoring analog device [" << (*ignoreCondition).second->analogDeviceId << "]"
+                << ", state=" << (*condition).second->state);
 
-		      if ((*ignoreCondition).second->analogDevice->ignored != (*condition).second->state)
-			{
-			  reload = true; // reload configuration!
-			}
+              if ((*ignoreCondition).second->analogDevice->ignored != (*condition).second->state)
+            {
+              reload = true; // reload configuration!
+            }
 
-		      (*ignoreCondition).second->analogDevice->ignored = (*condition).second->state;
-		    }
-		}
-	    }
-	}
+              (*ignoreCondition).second->analogDevice->ignored = (*condition).second->state;
+            }
+        }
+        }
+    }
     }
 
     return reload;
@@ -761,15 +761,15 @@ void Engine::mitigate()
                                     (*allowed).second->beamClass;
 
                                 LOG_TRACE("ENGINE", (*allowed).second->beamDestination->name
-					  << " tentative class set to "
+                      << " tentative class set to "
                                     << (*allowed).second->beamClass->number);
                             }
                         }
                     }
-		    else {
-		      LOG_TRACE("ENGINE", "WARN: no AllowedClasses found for "
-				<< (*fault).second->name << " fault");
-		    }
+            else {
+              LOG_TRACE("ENGINE", "WARN: no AllowedClasses found for "
+                << (*fault).second->name << " fault");
+            }
                 }
             }
 
@@ -825,7 +825,7 @@ int Engine::checkFaults()
       reload = evaluateIgnoreConditions();
       mitigate();
       if (checkAomState()) {
-	reload = true;
+    reload = true;
       }
       setAllowedBeamClass();
     }
@@ -864,25 +864,25 @@ void Engine::showFaults()
     {
       std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
       for (DbFaultMap::iterator fault = _mpsDb->faults->begin();
-	   fault != _mpsDb->faults->end(); ++fault)
-	{
-	  for (DbFaultStateMap::iterator state = (*fault).second->faultStates->begin();
-	       state != (*fault).second->faultStates->end(); ++state)
-	    {
-	      if ((*state).second->faulted)
-		{
-		  if (!faults)
-		    {
-		      std::cout << "# Current faults:" << std::endl;
-		      faults = true;
-		    }
+       fault != _mpsDb->faults->end(); ++fault)
+    {
+      for (DbFaultStateMap::iterator state = (*fault).second->faultStates->begin();
+           state != (*fault).second->faultStates->end(); ++state)
+        {
+          if ((*state).second->faulted)
+        {
+          if (!faults)
+            {
+              std::cout << "# Current faults:" << std::endl;
+              faults = true;
+            }
 
-		  std::cout << "  " << (*fault).second->name << ": " << (*state).second->deviceState->name
-			    << " (value=" << (*state).second->deviceState->value << ", ignored="
-			    << (*state).second->ignored << ")" << std::endl;
-		}
-	    }
-	}
+          std::cout << "  " << (*fault).second->name << ": " << (*state).second->deviceState->name
+                << " (value=" << (*state).second->deviceState->value << ", ignored="
+                << (*state).second->ignored << ")" << std::endl;
+        }
+        }
+    }
     }
 
     if (!faults)
@@ -902,26 +902,26 @@ void Engine::showStats()
         std::cout << "Rate: " << Engine::_rate << " Hz" << std::endl;
 
         if (_shutterDevice)
-	        std::cout << "Shutter Status: " << Engine::_shutterDevice->value
-		        << " (CLOSED=" << Engine::_shutterClosedStatus << ")" << std::endl;
+            std::cout << "Shutter Status: " << Engine::_shutterDevice->value
+                << " (CLOSED=" << Engine::_shutterClosedStatus << ")" << std::endl;
 
         if (_aomDestination)
         {
-	        std::cout << "AOM Status: ";
-	        if (Engine::_aomAllowWhileShutterClosed)
-	            std::cout << " ALLOWED ";
+            std::cout << "AOM Status: ";
+            if (Engine::_aomAllowWhileShutterClosed)
+                std::cout << " ALLOWED ";
             else
-	            std::cout << " Normal ";
+                std::cout << " Normal ";
 
-	        std::cout << "[" << Engine::_aomAllowEnableCounter << "/"
-		        << Engine::_aomAllowDisableCounter << "]" << std::endl;
+            std::cout << "[" << Engine::_aomAllowEnableCounter << "/"
+                << Engine::_aomAllowDisableCounter << "]" << std::endl;
         }
 
-	    std::cout << "Reload latch: " << Engine::_linacFwLatch << std::endl;
-	    std::cout << "Reload Config Count: " << Engine::_reloadCount << std::endl;
+        std::cout << "Reload latch: " << Engine::_linacFwLatch << std::endl;
+        std::cout << "Reload Config Count: " << Engine::_reloadCount << std::endl;
 
         if (_aomDestination)
-	        std::cout << "Allow AOM (shutter closed): " << Engine::_aomAllowWhileShutterClosed << std::endl;
+            std::cout << "Allow AOM (shutter closed): " << Engine::_aomAllowWhileShutterClosed << std::endl;
 
         std::cout << "Counter: " << Engine::_updateCounter << std::endl;
         std::cout << "Input Update Fail Counter: " << Engine::_inputUpdateFailCounter
@@ -1106,12 +1106,12 @@ void Engine::engineThread()
                 std::unique_lock<std::mutex> lock(*(Engine::getInstance()._mpsDb->getInputUpdateMutex()));
                 while(!Engine::getInstance()._mpsDb->isInputReady())
                 {
-		  Engine::getInstance()._mpsDb->getInputUpdateCondVar()->wait_for(lock, std::chrono::milliseconds(5));
-		  if (!_evaluate) {
-		    engineLock.unlock();
-		    std::cout << "INFO: EngineThread: Exiting..." << std::endl;
-		    return;
-		  }
+          Engine::getInstance()._mpsDb->getInputUpdateCondVar()->wait_for(lock, std::chrono::milliseconds(5));
+          if (!_evaluate) {
+            engineLock.unlock();
+            std::cout << "INFO: EngineThread: Exiting..." << std::endl;
+            return;
+          }
                 }
             }
 
@@ -1121,11 +1121,11 @@ void Engine::engineThread()
                 while(!Engine::getInstance()._mpsDb->isMitBufferWriteReady())
                 {
                     Engine::getInstance()._mpsDb->getMitBufferCondVar()->wait_for(lock, std::chrono::milliseconds(5));
-		    if (!_evaluate) {
-		      engineLock.unlock();
-		      std::cout << "INFO: EngineThread: Exiting..." << std::endl;
-		      return;
-		    }
+            if (!_evaluate) {
+              engineLock.unlock();
+              std::cout << "INFO: EngineThread: Exiting..." << std::endl;
+              return;
+            }
                 }
             }
 
@@ -1170,7 +1170,7 @@ void Engine::engineThread()
             sleep(1);
         }
 
-	engineLock.unlock();
+    engineLock.unlock();
     }
 
     Firmware::getInstance().setSoftwareEnable(false);

--- a/src/central_node_engine.cc
+++ b/src/central_node_engine.cc
@@ -1062,7 +1062,7 @@ void Engine::engineThread()
     std::cout << "INFO: Engine: update thread started." << std::endl;
 
     // Declare as real time task
-    param.sched_priority = 75;
+    param.sched_priority = 88;
     if(sched_setscheduler(0, SCHED_FIFO, &param) == -1)
     {
         perror("Set priority");

--- a/src/central_node_engine.cc
+++ b/src/central_node_engine.cc
@@ -23,18 +23,19 @@ time_t          Engine::_startTime;
 uint32_t        Engine::_inputUpdateFailCounter;
 bool            Engine::_enableMps = false;
 
-Engine::Engine() :
-  _initialized(false),
-  _engineThread(NULL),
-  _debugCounter(0),
-  _aomAllowWhileShutterClosed(false),
-  _aomAllowEnableCounter(0),
-  _aomAllowDisableCounter(0),
-  _linacFwLatch(false),
-  _reloadCount(0),
-  _checkFaultTime( "Evaluation only time", 720 ),
-  _evaluationCycleTime( "Evaluation Cycle time", 720 ),
-  hb( Firmware::getInstance().getRoot(), 3500, 720 )
+Engine::Engine()
+:
+    _initialized(false),
+    _engineThread(NULL),
+    _debugCounter(0),
+    _aomAllowWhileShutterClosed(false),
+    _aomAllowEnableCounter(0),
+    _aomAllowDisableCounter(0),
+    _linacFwLatch(false),
+    _reloadCount(0),
+    _checkFaultTime( "Evaluation only time", 720 ),
+    _evaluationCycleTime( "Evaluation Cycle time", 720 ),
+    hb( Firmware::getInstance().getRoot(), 3500, 720 )
 {
 #if defined(LOG_ENABLED) && !defined(LOG_STDOUT)
     engineLogger = Loggers::getLogger("ENGINE");
@@ -57,7 +58,6 @@ Engine::Engine() :
 
 Engine::~Engine()
 {
-
 #if defined(LOG_ENABLED)
     //  Firmware::getInstance().showStats();
 #endif
@@ -97,8 +97,8 @@ int Engine::reloadConfig()
     }
 
     {
-      std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
-      _mpsDb->writeFirmwareConfiguration();
+        std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
+        _mpsDb->writeFirmwareConfiguration();
     }
 
     _evaluate = true;
@@ -111,24 +111,24 @@ int Engine::reloadConfig()
 // This is called when analog devices need to be ignored (and un-ignored)
 int Engine::reloadConfigFromIgnore()
 {
-  Firmware::getInstance().setEvaluationEnable(false);
-  Firmware::getInstance().setSoftwareEnable(false);
-  Firmware::getInstance().setEnable(false);
+    Firmware::getInstance().setEvaluationEnable(false);
+    Firmware::getInstance().setSoftwareEnable(false);
+    Firmware::getInstance().setEnable(false);
 
-  {
-    std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
-    _mpsDb->writeFirmwareConfiguration(_aomAllowWhileShutterClosed);
-  }
+    {
+        std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
+        _mpsDb->writeFirmwareConfiguration(_aomAllowWhileShutterClosed);
+    }
 
-  Firmware::getInstance().setEnable(true);
-  Firmware::getInstance().clearAll();
-  //  Firmware::getInstance().softwareClear();
-  Firmware::getInstance().setSoftwareEnable(true);
-  Firmware::getInstance().setEvaluationEnable(true);
+    Firmware::getInstance().setEnable(true);
+    Firmware::getInstance().clearAll();
+    //  Firmware::getInstance().softwareClear();
+    Firmware::getInstance().setSoftwareEnable(true);
+    Firmware::getInstance().setEvaluationEnable(true);
 
-  ++_reloadCount;
+    ++_reloadCount;
 
-  return 0;
+    return 0;
 }
 
 int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
@@ -151,9 +151,9 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
     if (_evaluate)
     {
         _evaluate = false;
-    engineLock.unlock();
+        engineLock.unlock();
         threadJoin();
-    engineLock.lock();
+        engineLock.lock();
     }
 
     _evaluate = false;
@@ -162,99 +162,99 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
     boost::shared_ptr<MpsDb> mpsDb = boost::shared_ptr<MpsDb>(db);
 
     {
-      std::unique_lock<std::mutex> lock(*mpsDb->getMutex()); // the database mutex is static - is the same for all instances
+        std::unique_lock<std::mutex> lock(*mpsDb->getMutex()); // the database mutex is static - is the same for all instances
 
-      if (mpsDb->load(yamlFileName) != 0)
-    {
-      _errorStream.str(std::string());
-      _errorStream << "ERROR: Failed to load yaml database ("
-               << yamlFileName << ")";
-      throw(EngineException(_errorStream.str()));
-    }
-
-      LOG_TRACE("ENGINE", "YAML Database loaded from " << yamlFileName);
-
-      // When the first yaml configuration file is loaded the bypassMap
-      // must be created.
-      //
-      // TODO/Database/Important: the bypasses are created for each device input and
-      // analog channel in the database, this happens for the first time
-      // a database is loaded. If there are subsequent database changes
-      // they must have the same device inputs and analog channels.
-      // Currently if the number of channels differ between the loaded
-      // databases the central node engine must be restarted.
-      if (!_bypassManager)
-    {
-      _bypassManager = BypassManagerPtr(new BypassManager());
-      _bypassManager->createBypassMap(mpsDb);
-      _bypassManager->startBypassThread();
-    }
-
-      LOG_TRACE("ENGINE", "BypassManager created");
-
-      try
-    {
-      mpsDb->configure();
-    }
-      catch (DbException &e)
-    {
-      throw e;
-    }
-
-      LOG_TRACE("ENGINE", "MPS Database configured from YAML");
-
-      // Assign bypass to each digital/analog input
-      try
-    {
-      _bypassManager->assignBypass(mpsDb);
-    }
-      catch (CentralNodeException &e)
-    {
-      _initialized = true;
-      _evaluate = true;
-      startUpdateThread();
-      throw e;
-    }
-
-      // Now that the database has been loaded and configured
-      // successfully, assign to _mpsDb shared_ptr
-      _mpsDb = mpsDb;//shared_ptr<MpsDb>(db);
-
-      // Search for Mech. Shutter device - this is needed to keep track
-      // of the shutter status, and allow AOM when the shutter is closed
-      // If it is not found, we will let the system run, but we won't be
-      // able to keep track of the shutter status. This is needed for the
-      // dual-core operation.
-      if (!findShutterDevice()) {
-        std::cout << "Mech. Shutter device not found." << std::endl;
-      }
-
-      // We allow the system to run without finding both the Linac and the AOM.
-      // This is needed for the dual-core operation.
-      if (!findBeamDestinations()) {
-        std::cout << "AOM and/or Linac beam destination not found." << std::endl;
-      }
-
-      // Find the lowest/highest BeamClasses - used when checking faults
-      uint32_t num = 0;
-      uint32_t lowNum = 100;
-      for (DbBeamClassMap::iterator beamClass = _mpsDb->beamClasses->begin();
-       beamClass != _mpsDb->beamClasses->end(); ++beamClass)
-    {
-      if ((*beamClass).second->number > num)
+        if (mpsDb->load(yamlFileName) != 0)
         {
-          _highestBeamClass = (*beamClass).second;
-          num = (*beamClass).second->number;
+            _errorStream.str(std::string());
+            _errorStream << "ERROR: Failed to load yaml database ("
+                << yamlFileName << ")";
+            throw(EngineException(_errorStream.str()));
         }
 
-      if ((*beamClass).second->number < lowNum)
-        {
-          _lowestBeamClass = (*beamClass).second;
-          lowNum = (*beamClass).second->number;
-        }
-    }
+        LOG_TRACE("ENGINE", "YAML Database loaded from " << yamlFileName);
 
-      _mpsDb->writeFirmwareConfiguration();
+        // When the first yaml configuration file is loaded the bypassMap
+        // must be created.
+        //
+        // TODO/Database/Important: the bypasses are created for each device input and
+        // analog channel in the database, this happens for the first time
+        // a database is loaded. If there are subsequent database changes
+        // they must have the same device inputs and analog channels.
+        // Currently if the number of channels differ between the loaded
+        // databases the central node engine must be restarted.
+        if (!_bypassManager)
+        {
+            _bypassManager = BypassManagerPtr(new BypassManager());
+            _bypassManager->createBypassMap(mpsDb);
+            _bypassManager->startBypassThread();
+        }
+
+        LOG_TRACE("ENGINE", "BypassManager created");
+
+        try
+        {
+            mpsDb->configure();
+        }
+        catch (DbException &e)
+        {
+            throw e;
+        }
+
+        LOG_TRACE("ENGINE", "MPS Database configured from YAML");
+
+        // Assign bypass to each digital/analog input
+        try
+        {
+            _bypassManager->assignBypass(mpsDb);
+        }
+        catch (CentralNodeException &e)
+        {
+            _initialized = true;
+            _evaluate = true;
+            startUpdateThread();
+            throw e;
+        }
+
+        // Now that the database has been loaded and configured
+        // successfully, assign to _mpsDb shared_ptr
+        _mpsDb = mpsDb;//shared_ptr<MpsDb>(db);
+
+        // Search for Mech. Shutter device - this is needed to keep track
+        // of the shutter status, and allow AOM when the shutter is closed
+        // If it is not found, we will let the system run, but we won't be
+        // able to keep track of the shutter status. This is needed for the
+        // dual-core operation.
+        if (!findShutterDevice())
+            std::cout << "Mech. Shutter device not found." << std::endl;
+
+
+        // We allow the system to run without finding both the Linac and the AOM.
+        // This is needed for the dual-core operation.
+        if (!findBeamDestinations())
+            std::cout << "AOM and/or Linac beam destination not found." << std::endl;
+
+        // Find the lowest/highest BeamClasses - used when checking faults
+        uint32_t num = 0;
+        uint32_t lowNum = 100;
+        for (DbBeamClassMap::iterator beamClass = _mpsDb->beamClasses->begin();
+            beamClass != _mpsDb->beamClasses->end();
+            ++beamClass)
+        {
+            if ((*beamClass).second->number > num)
+            {
+                _highestBeamClass = (*beamClass).second;
+                num = (*beamClass).second->number;
+            }
+
+            if ((*beamClass).second->number < lowNum)
+            {
+                _lowestBeamClass = (*beamClass).second;
+                lowNum = (*beamClass).second->number;
+            }
+        }
+
+        _mpsDb->writeFirmwareConfiguration();
     }
 
     LOG_TRACE("ENGINE", "Lowest beam class found: " << _lowestBeamClass->number);
@@ -270,45 +270,47 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
     return 0;
 }
 
-bool Engine::findBeamDestinations() {
-  for (DbBeamDestinationMap::iterator it = _mpsDb->beamDestinations->begin();
-       it != _mpsDb->beamDestinations->end(); ++it) {
-    if ((*it).second->name == "AOM") {
-      _aomDestination = (*it).second;
+bool Engine::findBeamDestinations()
+{
+    for (DbBeamDestinationMap::iterator it = _mpsDb->beamDestinations->begin();
+        it != _mpsDb->beamDestinations->end();
+        ++it)
+    {
+        if ((*it).second->name == "AOM")
+            _aomDestination = (*it).second;
+        else if ((*it).second->name == "Linac")
+            _linacDestination = (*it).second;
     }
-    else if ((*it).second->name == "Linac") {
-      _linacDestination = (*it).second;
-    }
-  }
 
-  if (!_aomDestination or !_linacDestination) {
-    return false;
-  }
+    if (!_aomDestination or !_linacDestination)
+        return false;
 
-  return true;
+    return true;
 }
 
 bool Engine::findShutterDevice()
 {
-  for (DbDigitalDeviceMap::iterator device = _mpsDb->digitalDevices->begin();
-       device != _mpsDb->digitalDevices->end(); ++device)
+    for (DbDigitalDeviceMap::iterator device = _mpsDb->digitalDevices->begin();
+        device != _mpsDb->digitalDevices->end();
+        ++device)
     {
-      if ((*device).second->name == "Mech. Shutter")
-    {
-      _shutterDevice = (*device).second;
-      for (DbDeviceStateMap::iterator state = _shutterDevice->deviceType->deviceStates->begin();
-           state != _shutterDevice->deviceType->deviceStates->end(); ++state)
+        if ((*device).second->name == "Mech. Shutter")
         {
-          if ((*state).second->name == "CLOSED")
-        {
-          _shutterClosedStatus = (*state).second->value;
-          return true;
+            _shutterDevice = (*device).second;
+            for (DbDeviceStateMap::iterator state = _shutterDevice->deviceType->deviceStates->begin();
+                state != _shutterDevice->deviceType->deviceStates->end();
+                ++state)
+            {
+                if ((*state).second->name == "CLOSED")
+                {
+                    _shutterClosedStatus = (*state).second->value;
+                    return true;
+                }
+            }
         }
-        }
-    }
     }
 
-  return false;
+    return false;
 }
 
 bool Engine::isInitialized()
@@ -345,17 +347,18 @@ void Engine::setTentativeBeamClass()
  */
 bool Engine::setAllowedBeamClass()
 {
-  // Set the allowed classes according to the SW evaluation
-  for (DbBeamDestinationMap::iterator it = _mpsDb->beamDestinations->begin();
-       it != _mpsDb->beamDestinations->end(); ++it)
+    // Set the allowed classes according to the SW evaluation
+    for (DbBeamDestinationMap::iterator it = _mpsDb->beamDestinations->begin();
+        it != _mpsDb->beamDestinations->end();
+        ++it)
     {
-      (*it).second->setAllowedBeamClass();
-      //    (*it).second->allowedBeamClass = (*it).second->tentativeBeamClass;
-      LOG_TRACE("ENGINE", (*it).second->name << " allowed class set to "
-        << (*it).second->allowedBeamClass->number);
+        (*it).second->setAllowedBeamClass();
+        //    (*it).second->allowedBeamClass = (*it).second->tentativeBeamClass;
+        LOG_TRACE("ENGINE", (*it).second->name << " allowed class set to "
+            << (*it).second->allowedBeamClass->number);
     }
 
-  return true;
+    return true;
 }
 
 /**
@@ -404,96 +407,97 @@ bool Engine::setAllowedBeamClass()
  * are all defined in the DB. Otherwise, this check will
  * do nothing and simply return false.
  */
-bool Engine::checkAomState() {
-  // Check if the shutter device and both the Linac and AOM destinations
-  // are defined. Otherwise just reutrn false.
-  if (!_aomDestination or !_linacDestination or !_shutterDevice)
-      return false;
+bool Engine::checkAomState()
+{
+    // Check if the shutter device and both the Linac and AOM destinations
+    // are defined. Otherwise just reutrn false.
+    if (!_aomDestination or !_linacDestination or !_shutterDevice)
+        return false;
 
-  bool reload = false;
+    bool reload = false;
 
-  // Check whether there is an active FW latch mitigation
-  uint32_t latchedMitigation[2];
-  Firmware::getInstance().getLatchedMitigation(&latchedMitigation[0]);
-  uint32_t linacLatchedMitigation = latchedMitigation[1] & 0xF;
+    // Check whether there is an active FW latch mitigation
+    uint32_t latchedMitigation[2];
+    Firmware::getInstance().getLatchedMitigation(&latchedMitigation[0]);
+    uint32_t linacLatchedMitigation = latchedMitigation[1] & 0xF;
 
-  // Read the current mitigation (result of both SW/FW evaluations)
-  uint32_t mitigation[2];
-  Firmware::getInstance().getMitigation(&mitigation[0]);
-  uint32_t linacMitigation = mitigation[1] & 0xF;
+    // Read the current mitigation (result of both SW/FW evaluations)
+    uint32_t mitigation[2];
+    Firmware::getInstance().getMitigation(&mitigation[0]);
+    uint32_t linacMitigation = mitigation[1] & 0xF;
 
-  bool shutterClosed = false;
-  if (_shutterDevice->value == _shutterClosedStatus) {
-    shutterClosed = true;
-  }
+    bool shutterClosed = false;
+    if (_shutterDevice->value == _shutterClosedStatus)
+        shutterClosed = true;
 
-  // First condition - shutter is closed, it is supposed to be closed and
-  // we are not in the force AOM mode already
-  // then removes AOM from FW evaluation (by reloading)
-  if (shutterClosed &&
-      !_aomAllowWhileShutterClosed &&
-    shouldShutterBeClosed(linacMitigation==0)) {
+    // First condition - shutter is closed, it is supposed to be closed and
+    // we are not in the force AOM mode already
+    // then removes AOM from FW evaluation (by reloading)
+    if (shutterClosed &&
+        !_aomAllowWhileShutterClosed &&
+        shouldShutterBeClosed(linacMitigation==0))
+    {
+        // If the FW linac mitigation is ON then latch it in SW, because the FW
+        // reload operation will unlatch it
+        if (linacLatchedMitigation == 0)
+            _linacFwLatch = true; // This is cleared only by OPS
 
-    // If the FW linac mitigation is ON then latch it in SW, because the FW
-    // reload operation will unlatch it
-    if (linacLatchedMitigation == 0) {
-      _linacFwLatch = true; // This is cleared only by OPS
+        _aomAllowWhileShutterClosed = true; // This causes AOM to be bypassed by FW
+        ++_aomAllowEnableCounter;
+        reload = true;
     }
 
-    _aomAllowWhileShutterClosed = true; // This causes AOM to be bypassed by FW
-    ++_aomAllowEnableCounter;
-    reload = true;
-  }
+    // Set PC0 to shutter in SW if it was latched in FW before reload
+    if (_linacFwLatch)
+        _linacDestination->tentativeBeamClass = _lowestBeamClass;
 
-  // Set PC0 to shutter in SW if it was latched in FW before reload
-  if (_linacFwLatch) {
-    _linacDestination->tentativeBeamClass = _lowestBeamClass;
-  }
+    // Set high PC to AOM if _aomAllowWhileShutterClosed is active
+    if (_aomAllowWhileShutterClosed)
+        _aomDestination->tentativeBeamClass = _highestBeamClass;
 
-  // Set high PC to AOM if _aomAllowWhileShutterClosed is active
-  if (_aomAllowWhileShutterClosed) {
-    _aomDestination->tentativeBeamClass = _highestBeamClass;
-  }
 
-  // Second condition - shutter is closed, but there are no faults,
-  // it could be opened, first close AOM
-  if (shutterClosed && _aomAllowWhileShutterClosed &&
-      shouldShutterBeOpened(linacLatchedMitigation==0, linacMitigation==0)) {
-    _aomDestination->tentativeBeamClass = _lowestBeamClass;
-    _aomAllowWhileShutterClosed = false;
-    ++_aomAllowDisableCounter;
-    reload = true;
-  }
-  // Otherwise, if shutter is not closed - then disallow AOM
-  else if (!shutterClosed && _aomAllowWhileShutterClosed) {
-    ++_aomAllowDisableCounter;
-    _aomAllowWhileShutterClosed = false;
-    reload = true;
-  }
+    // Second condition - shutter is closed, but there are no faults,
+    // it could be opened, first close AOM
+    if (shutterClosed && _aomAllowWhileShutterClosed &&
+        shouldShutterBeOpened(linacLatchedMitigation==0, linacMitigation==0))
+    {
+        _aomDestination->tentativeBeamClass = _lowestBeamClass;
+        _aomAllowWhileShutterClosed = false;
+        ++_aomAllowDisableCounter;
+        reload = true;
+    }
+    // Otherwise, if shutter is not closed - then disallow AOM
+    else if (!shutterClosed && _aomAllowWhileShutterClosed)
+    {
+        ++_aomAllowDisableCounter;
+        _aomAllowWhileShutterClosed = false;
+        reload = true;
+    }
 
-  return reload;
+    return reload;
 }
 
 /**
  * Returns whether the shutter is supposed to be closed.
  */
-bool Engine::shouldShutterBeClosed(bool linacMitigation) {
-  bool shouldBeClosed = linacMitigation || _linacFwLatch;
-  return shouldBeClosed; // TODO: Include other conditions, e.g. app timed out
+bool Engine::shouldShutterBeClosed(bool linacMitigation)
+{
+    bool shouldBeClosed = linacMitigation || _linacFwLatch;
+    return shouldBeClosed; // TODO: Include other conditions, e.g. app timed out
 }
 
 /**
  * Retuns whether the shutter is supposed to be opened
  */
-bool Engine::shouldShutterBeOpened(bool linacFwLatchedMitigation, bool linacMitigation) {
-  bool swFaultActive = true;
-  if (_linacDestination->tentativeBeamClass != _lowestBeamClass) {
-    swFaultActive = false;
-  }
+bool Engine::shouldShutterBeOpened(bool linacFwLatchedMitigation, bool linacMitigation)
+{
+    bool swFaultActive = true;
+    if (_linacDestination->tentativeBeamClass != _lowestBeamClass)
+        swFaultActive = false;
 
-  bool shouldBeOpened = !swFaultActive && !linacFwLatchedMitigation && !linacMitigation;
+    bool shouldBeOpened = !swFaultActive && !linacFwLatchedMitigation && !linacMitigation;
 
-  return shouldBeOpened;
+    return shouldBeOpened;
 }
 
 /**
@@ -517,53 +521,57 @@ void Engine::evaluateFaults()
     for (DbDigitalDeviceMap::iterator device = _mpsDb->digitalDevices->begin();
         device != _mpsDb->digitalDevices->end(); ++device)
     {
-      // If device has no card assigned, then it cannot be evaluated.
-      if ((*device).second->cardId != NO_CARD_ID &&
-      (*device).second->evaluation != NO_EVALUATION) {
-        uint32_t deviceValue = 0;
-        LOG_TRACE("ENGINE", "Getting inputs for " << (*device).second->name << " device"
-            << ", there are " << (*device).second->inputDevices->size()
-            << " inputs");
-
-        for (DbDeviceInputMap::iterator input = (*device).second->inputDevices->begin();
-            input != (*device).second->inputDevices->end(); ++input)
+        // If device has no card assigned, then it cannot be evaluated.
+        if ((*device).second->cardId != NO_CARD_ID &&
+            (*device).second->evaluation != NO_EVALUATION)
         {
-            uint32_t inputValue = 0;
-            // Check if the input has a valid bypass value
-            if ((*input).second->bypass->status == BYPASS_VALID)
+            uint32_t deviceValue = 0;
+            LOG_TRACE("ENGINE", "Getting inputs for " << (*device).second->name << " device"
+                << ", there are " << (*device).second->inputDevices->size()
+                << " inputs");
+
+            for (DbDeviceInputMap::iterator input = (*device).second->inputDevices->begin();
+                input != (*device).second->inputDevices->end();
+                ++input)
             {
-                inputValue = (*input).second->bypass->value;
-                LOG_TRACE("ENGINE", (*device).second->name << " bypassing input value to "
-                    << (*input).second->bypass->value << " (actual value is "
-                    << (*input).second->value << ")");
-            }
-            else
-            {
-                inputValue = (*input).second->value;
+                uint32_t inputValue = 0;
+                // Check if the input has a valid bypass value
+                if ((*input).second->bypass->status == BYPASS_VALID)
+                {
+                    inputValue = (*input).second->bypass->value;
+                    LOG_TRACE("ENGINE", (*device).second->name << " bypassing input value to "
+                        << (*input).second->bypass->value << " (actual value is "
+                        << (*input).second->value << ")");
+                }
+                else
+                {
+                    inputValue = (*input).second->value;
+                }
+
+                inputValue <<= (*input).second->bitPosition;
+                deviceValue |= inputValue;
             }
 
-            inputValue <<= (*input).second->bitPosition;
-            deviceValue |= inputValue;
+            (*device).second->update(deviceValue);
+
+            LOG_TRACE("ENGINE", (*device).second->name << " current value " << std::hex << deviceValue << std::dec);
         }
-
-        (*device).second->update(deviceValue);
-
-        LOG_TRACE("ENGINE", (*device).second->name << " current value " << std::hex << deviceValue << std::dec);
-      }
     }
 
     // At this point all digital devices have an updated value
 
     // Update digital & analog Fault values and BeamDestination allowed class
     for (DbFaultMap::iterator fault = _mpsDb->faults->begin();
-        fault != _mpsDb->faults->end(); ++fault)
+        fault != _mpsDb->faults->end();
+        ++fault)
     {
         LOG_TRACE("ENGINE", (*fault).second->name << " updating fault values");
 
         // First calculate the digital Fault value from its one or more digital device inputs
         uint32_t faultValue = 0;
         for (DbFaultInputMap::iterator input = (*fault).second->faultInputs->begin();
-            input != (*fault).second->faultInputs->end(); ++input)
+            input != (*fault).second->faultInputs->end();
+            ++input)
         {
             uint32_t inputValue = 0;
             if ((*input).second->digitalDevice)
@@ -594,7 +602,8 @@ void Engine::evaluateFaults()
         // Now that a Fault has a new value check if it is in the FaultStates list,
         // and update the allowedBeamClass for the BeamDestinations
         for (DbFaultStateMap::iterator state = (*fault).second->faultStates->begin();
-            state != (*fault).second->faultStates->end(); ++state)
+            state != (*fault).second->faultStates->end();
+            ++state)
         {
             (*state).second->ignored = false; // Mark not ignored - the ignore logic is evaluated later
             uint32_t maskedValue = faultValue & (*state).second->deviceState->mask;
@@ -650,7 +659,8 @@ bool Engine::evaluateIgnoreConditions()
 
     // Calculate state of conditions
     for (DbConditionMap::iterator condition = _mpsDb->conditions->begin();
-        condition != _mpsDb->conditions->end(); ++condition)
+        condition != _mpsDb->conditions->end();
+        ++condition)
     {
         uint32_t conditionValue = 0;
         for (DbConditionInputMap::iterator input = (*condition).second->conditionInputs->begin();
@@ -660,9 +670,7 @@ bool Engine::evaluateIgnoreConditions()
             if ((*input).second->faultState)
             {
                 if ((*input).second->faultState->faulted)
-                {
                     inputValue = 1;
-                }
             }
 
             conditionValue |= (inputValue << (*input).second->bitPosition);
@@ -675,50 +683,50 @@ bool Engine::evaluateIgnoreConditions()
         // 'mask' is the condition value that needs to be matched in order to ignore faults
         bool newConditionState = false;
         if ((*condition).second->mask == conditionValue)
-        {
             newConditionState = true;
-        }
 
         (*condition).second->state = newConditionState;
         LOG_TRACE("ENGINE",  "Condition " << (*condition).second->name << " is " << (*condition).second->state);
 
-    if ((*condition).second->ignoreConditions) {
-      for (DbIgnoreConditionMap::iterator ignoreCondition = (*condition).second->ignoreConditions->begin();
-           ignoreCondition != (*condition).second->ignoreConditions->end(); ++ignoreCondition)
+        if ((*condition).second->ignoreConditions)
         {
-          if ((*ignoreCondition).second->faultState)
-        {
-          LOG_TRACE("ENGINE",  "Ignoring fault state [" << (*ignoreCondition).second->faultStateId << "]"
-                << ", state=" << (*condition).second->state);
-
-          (*ignoreCondition).second->faultState->ignored = (*condition).second->state;
-          // This check is needed in case specific faults from an AnalogDevice is
-          // listed in the ignoreCondition.
-          if ((*ignoreCondition).second->analogDevice) {
-            int integrator = (*ignoreCondition).second->faultState->deviceState->getIntegrator();
-            if ((*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] != (*condition).second->state) {
-              reload = true; // reload configuration!
-            }
-            (*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] = (*condition).second->state;
-          }
-        }
-          else
-        {
-          if ((*ignoreCondition).second->analogDevice)
+            for (DbIgnoreConditionMap::iterator ignoreCondition = (*condition).second->ignoreConditions->begin();
+                ignoreCondition != (*condition).second->ignoreConditions->end();
+                ++ignoreCondition)
             {
-              LOG_TRACE("ENGINE",  "Ignoring analog device [" << (*ignoreCondition).second->analogDeviceId << "]"
-                << ", state=" << (*condition).second->state);
+                if ((*ignoreCondition).second->faultState)
+                {
+                    LOG_TRACE("ENGINE",  "Ignoring fault state [" << (*ignoreCondition).second->faultStateId << "]"
+                        << ", state=" << (*condition).second->state);
 
-              if ((*ignoreCondition).second->analogDevice->ignored != (*condition).second->state)
-            {
-              reload = true; // reload configuration!
-            }
+                    (*ignoreCondition).second->faultState->ignored = (*condition).second->state;
 
-              (*ignoreCondition).second->analogDevice->ignored = (*condition).second->state;
+                    // This check is needed in case specific faults from an AnalogDevice is
+                    // listed in the ignoreCondition.
+                    if ((*ignoreCondition).second->analogDevice)
+                    {
+                        int integrator = (*ignoreCondition).second->faultState->deviceState->getIntegrator();
+                        if ((*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] != (*condition).second->state)
+                            reload = true; // reload configuration!
+
+                        (*ignoreCondition).second->analogDevice->ignoredIntegrator[integrator] = (*condition).second->state;
+                    }
+                }
+                else
+                {
+                    if ((*ignoreCondition).second->analogDevice)
+                    {
+                        LOG_TRACE("ENGINE",  "Ignoring analog device [" << (*ignoreCondition).second->analogDeviceId << "]"
+                            << ", state=" << (*condition).second->state);
+
+                        if ((*ignoreCondition).second->analogDevice->ignored != (*condition).second->state)
+                            reload = true; // reload configuration!
+
+                        (*ignoreCondition).second->analogDevice->ignored = (*condition).second->state;
+                    }
+                }
             }
         }
-        }
-    }
     }
 
     return reload;
@@ -728,7 +736,8 @@ void Engine::mitigate()
 {
     // Update digital Fault values and BeamDestination allowed class
     for (DbFaultMap::iterator fault = _mpsDb->faults->begin();
-        fault != _mpsDb->faults->end(); ++fault)
+        fault != _mpsDb->faults->end();
+        ++fault)
     {
         // Mitigate only those faults that are the result of slow evaluation
 #ifdef FAST_SW_EVALUATION
@@ -739,7 +748,8 @@ void Engine::mitigate()
         if ((*fault).second->evaluation == SLOW_EVALUATION) {
 #endif
             for (DbFaultStateMap::iterator state = (*fault).second->faultStates->begin();
-                state != (*fault).second->faultStates->end(); ++state)
+                state != (*fault).second->faultStates->end();
+                ++state)
             {
                 if ((*state).second->faulted && !(*state).second->ignored)
                 {
@@ -752,7 +762,8 @@ void Engine::mitigate()
                     if ((*state).second->allowedClasses)
                     {
                         for (DbAllowedClassMap::iterator allowed = (*state).second->allowedClasses->begin();
-                            allowed != (*state).second->allowedClasses->end(); ++allowed)
+                            allowed != (*state).second->allowedClasses->end();
+                            ++allowed)
                         {
                             if ((*allowed).second->beamDestination->tentativeBeamClass->number >
                                 (*allowed).second->beamClass->number)
@@ -761,15 +772,16 @@ void Engine::mitigate()
                                     (*allowed).second->beamClass;
 
                                 LOG_TRACE("ENGINE", (*allowed).second->beamDestination->name
-                      << " tentative class set to "
+                                    << " tentative class set to "
                                     << (*allowed).second->beamClass->number);
                             }
                         }
                     }
-            else {
-              LOG_TRACE("ENGINE", "WARN: no AllowedClasses found for "
-                << (*fault).second->name << " fault");
-            }
+                    else
+                    {
+                        LOG_TRACE("ENGINE", "WARN: no AllowedClasses found for "
+                            << (*fault).second->name << " fault");
+                    }
                 }
             }
 
@@ -786,7 +798,8 @@ void Engine::mitigate()
                     if ((*fault).second->defaultFaultState->allowedClasses)
                     {
                         for (DbAllowedClassMap::iterator allowed = (*fault).second->defaultFaultState->allowedClasses->begin();
-                            allowed != (*fault).second->defaultFaultState->allowedClasses->end(); ++allowed)
+                            allowed != (*fault).second->defaultFaultState->allowedClasses->end();
+                            ++allowed)
                         {
                             if ((*allowed).second->beamDestination->tentativeBeamClass->number >
                                 (*allowed).second->beamClass->number)
@@ -808,9 +821,7 @@ void Engine::mitigate()
 int Engine::checkFaults()
 {
     if (!_mpsDb)
-    {
         return 0;
-    }
 
     // must first get updated input values
     _checkFaultTime.start();
@@ -818,24 +829,23 @@ int Engine::checkFaults()
     LOG_TRACE("ENGINE", "Checking faults");
     bool reload = false;
     {
-      std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
-      _mpsDb->clearMitigationBuffer();
-      setTentativeBeamClass();
-      evaluateFaults();
-      reload = evaluateIgnoreConditions();
-      mitigate();
-      if (checkAomState()) {
-    reload = true;
-      }
-      setAllowedBeamClass();
+        std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
+        _mpsDb->clearMitigationBuffer();
+        setTentativeBeamClass();
+        evaluateFaults();
+        reload = evaluateIgnoreConditions();
+        mitigate();
+        if (checkAomState())
+            reload = true;
+
+        setAllowedBeamClass();
     }
+
     _checkFaultTime.tick();
 
     // If FW configuration needs reloading, return non-zero value
     if (reload)
-    {
         return 1;
-    }
 
     return 0;
 }
@@ -847,48 +857,46 @@ int Engine::checkFaults()
  */
 void Engine::clearSoftwareLatch()
 {
-   _linacFwLatch = false;
+    _linacFwLatch = false;
 }
 
 void Engine::showFaults()
 {
     if (!isInitialized())
-    {
         return;
-    }
 
     // Print current faults
     bool faults = false;
 
     // Digital Faults
     {
-      std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
-      for (DbFaultMap::iterator fault = _mpsDb->faults->begin();
-       fault != _mpsDb->faults->end(); ++fault)
-    {
-      for (DbFaultStateMap::iterator state = (*fault).second->faultStates->begin();
-           state != (*fault).second->faultStates->end(); ++state)
+        std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
+        for (DbFaultMap::iterator fault = _mpsDb->faults->begin();
+            fault != _mpsDb->faults->end();
+            ++fault)
         {
-          if ((*state).second->faulted)
-        {
-          if (!faults)
+            for (DbFaultStateMap::iterator state = (*fault).second->faultStates->begin();
+                state != (*fault).second->faultStates->end();
+                ++state)
             {
-              std::cout << "# Current faults:" << std::endl;
-              faults = true;
-            }
+                if ((*state).second->faulted)
+                {
+                    if (!faults)
+                    {
+                        std::cout << "# Current faults:" << std::endl;
+                        faults = true;
+                    }
 
-          std::cout << "  " << (*fault).second->name << ": " << (*state).second->deviceState->name
-                << " (value=" << (*state).second->deviceState->value << ", ignored="
-                << (*state).second->ignored << ")" << std::endl;
+                    std::cout << "  " << (*fault).second->name << ": " << (*state).second->deviceState->name
+                        << " (value=" << (*state).second->deviceState->value << ", ignored="
+                        << (*state).second->ignored << ")" << std::endl;
+                }
+            }
         }
-        }
-    }
     }
 
     if (!faults)
-    {
         std::cout << "# No faults" << std::endl;
-    }
 }
 
 void Engine::showStats()
@@ -1000,11 +1008,10 @@ void Engine::showDatabaseInfo()
 
 void Engine::startUpdateThread()
 {
-  _engineThread = new std::thread(&Engine::engineThread, this);
+    _engineThread = new std::thread(&Engine::engineThread, this);
 
-  if (pthread_setname_np(_engineThread->native_handle(), "EngineThread")) {
-    perror("pthread_setname_np failed");
-  }
+    if (pthread_setname_np(_engineThread->native_handle(), "EngineThread"))
+        perror("pthread_setname_np failed");
 }
 
 uint32_t Engine::getUpdateRate()
@@ -1029,10 +1036,11 @@ void Engine::threadExit()
 
 void Engine::threadJoin()
 {
-  if (_engineThread != NULL) {
-    std::cout << "INFO: Engine::threadJoin()" << std::endl;
-    _engineThread->join();
-  }
+    if (_engineThread != NULL)
+    {
+        std::cout << "INFO: Engine::threadJoin()" << std::endl;
+        _engineThread->join();
+    }
 }
 
 #define MAX_SAFE_STACK (8*1024) /* The maximum stack size which is
@@ -1074,12 +1082,14 @@ void Engine::engineThread()
 
     // Do not start MPS on the first time the thread runs (i.e.
     // when configuration is loaded)
-    if (!_enableMps) {
-      _enableMps = true;
+    if (!_enableMps)
+    {
+        _enableMps = true;
     }
-    else {
-      Firmware::getInstance().setEnable(true);
-      Firmware::getInstance().setSoftwareEnable(true);
+    else
+    {
+        Firmware::getInstance().setEnable(true);
+        Firmware::getInstance().setSoftwareEnable(true);
     }
 
     Firmware::getInstance().clearAll();
@@ -1097,7 +1107,7 @@ void Engine::engineThread()
 
     while(_evaluate)
     {
-      engineLock.lock();
+        engineLock.lock();
 
         if (Engine::getInstance()._mpsDb)
         {
@@ -1106,12 +1116,13 @@ void Engine::engineThread()
                 std::unique_lock<std::mutex> lock(*(Engine::getInstance()._mpsDb->getInputUpdateMutex()));
                 while(!Engine::getInstance()._mpsDb->isInputReady())
                 {
-          Engine::getInstance()._mpsDb->getInputUpdateCondVar()->wait_for(lock, std::chrono::milliseconds(5));
-          if (!_evaluate) {
-            engineLock.unlock();
-            std::cout << "INFO: EngineThread: Exiting..." << std::endl;
-            return;
-          }
+                    Engine::getInstance()._mpsDb->getInputUpdateCondVar()->wait_for(lock, std::chrono::milliseconds(5));
+                    if (!_evaluate)
+                    {
+                        engineLock.unlock();
+                        std::cout << "INFO: EngineThread: Exiting..." << std::endl;
+                        return;
+                    }
                 }
             }
 
@@ -1121,11 +1132,12 @@ void Engine::engineThread()
                 while(!Engine::getInstance()._mpsDb->isMitBufferWriteReady())
                 {
                     Engine::getInstance()._mpsDb->getMitBufferCondVar()->wait_for(lock, std::chrono::milliseconds(5));
-            if (!_evaluate) {
-              engineLock.unlock();
-              std::cout << "INFO: EngineThread: Exiting..." << std::endl;
-              return;
-            }
+                    if (!_evaluate)
+                    {
+                        engineLock.unlock();
+                        std::cout << "INFO: EngineThread: Exiting..." << std::endl;
+                        return;
+                    }
                 }
             }
 
@@ -1170,7 +1182,7 @@ void Engine::engineThread()
             sleep(1);
         }
 
-    engineLock.unlock();
+        engineLock.unlock();
     }
 
     Firmware::getInstance().setSoftwareEnable(false);
@@ -1196,14 +1208,15 @@ long Engine::getMaxEvalTime()
 
 long Engine::getAvgEvalTime()
 {
-  return static_cast<int>( _evaluationCycleTime.getMeanPeriod() * 1e6 );
+    return static_cast<int>( _evaluationCycleTime.getMeanPeriod() * 1e6 );
 }
 
-void Engine::clearMaxTimers() {
-  hb.clear();
-  _checkFaultTime.clear();
-  _evaluationCycleTime.clear();
-  _mpsDb->clearUpdateTime();
+void Engine::clearMaxTimers()
+{
+    hb.clear();
+    _checkFaultTime.clear();
+    _evaluationCycleTime.clear();
+    _mpsDb->clearUpdateTime();
 }
 
 long Engine::getAvgWdUpdatePeriod()

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -783,7 +783,7 @@ int64_t Firmware::readPCChangeStream(uint8_t *buffer, uint32_t size, uint64_t ti
     return ret;
 }
 
-void Firmware::writeMitigation(uint32_t *mitigation)
+void Firmware::writeMitigation(const std::vector<uint32_t>& mitigation)
 {
     //DEBUG
     //  mitigation[0] = 0x55667788;
@@ -791,7 +791,7 @@ void Firmware::writeMitigation(uint32_t *mitigation)
     //DEBUG
     try
     {
-        _swMitigationSV->setVal(mitigation, 2);
+        _swMitigationSV->setVal(const_cast<uint32_t*>(mitigation.data()), mitigation.size());
     }
     catch (IOError &e)
     {

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -614,15 +614,15 @@ void Firmware::writeTimingChecking(uint32_t time[], uint32_t period[], uint32_t 
     for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
       new_time[i] = 0;
       if (time[i] > 1000) {
-	// Set bits 25:16 first
-	new_time[i] = time[i]/1000 - 1;
-	new_time[i] <<= 16;
-	// Set lower bits next
-	new_time[i] |= 999;
+  // Set bits 25:16 first
+  new_time[i] = time[i]/1000 - 1;
+  new_time[i] <<= 16;
+  // Set lower bits next
+  new_time[i] |= 999;
       }
       else {
         if (time[i] != 0) {
-	  new_time[i] = time[i];
+    new_time[i] = time[i];
         }
       }
     }
@@ -703,8 +703,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_beamIntTimeSV->getVal(aux, FW_NUM_BEAM_CLASSES);
       os << "BeamIntTime=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-	os << aux[i];
-	if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
+  os << aux[i];
+  if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -712,8 +712,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_beamMinPeriodSV->getVal(aux, FW_NUM_BEAM_CLASSES);
       os << "BeamMinPeriod=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-	os << aux[i];
-	if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
+  os << aux[i];
+  if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -721,13 +721,13 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_beamIntChargeSV->getVal(aux, FW_NUM_BEAM_CLASSES);
       os << "BeamIntCharge=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-	os << aux[i];
-	if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
+  os << aux[i];
+  if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
       os << "BeamFaultReason=" << std::hex << "0x"
-	 << firmware->getUInt32(firmware->_beamFaultReasonSV) << std::dec << std::endl;
+   << firmware->getUInt32(firmware->_beamFaultReasonSV) << std::dec << std::endl;
 
       os << "BeamFaultEnable=";
       if (firmware->getBoolU64(firmware->_beamFaultEnSV)) os << "Enabled"; else os << "Disabled";
@@ -740,8 +740,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->extractMitigation(aux32, aux8);
       os << "Mitigation=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-	os << (int) aux8[i];
-	if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux8[i];
+  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -751,8 +751,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->extractMitigation(aux32, aux8);
       os << "FirmwareMitigation=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-	os << (int) aux8[i];
-	if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux8[i];
+  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -765,8 +765,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->extractMitigation(aux32, aux8);
       os << "SoftwareMitigation=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-	os << (int) aux8[i];
-	if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux8[i];
+  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -776,8 +776,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       //      firmware->getLatchedMitigation(aux8);
       os << "LatchedMitigation=[";
       for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-	os << (int) aux8[i];
-	if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux8[i];
+  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -785,8 +785,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_monitorRxErrorCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
       os << "MonitorRxErrorCnt=[";
       for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-	os << (int) aux[i];
-	if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux[i];
+  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -794,8 +794,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_monitorPauseCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
       os << "MonitorPauseCnt=[";
       for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-	os << (int) aux[i];
-	if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux[i];
+  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -803,8 +803,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_monitorOvflCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
       os << "MonitorOvflCnt=[";
       for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-	os << (int) aux[i];
-	if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux[i];
+  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -812,41 +812,41 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       firmware->_monitorDropCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
       os << "MonitorDropCnt=[";
       for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-	os << (int) aux[i];
-	if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
+  os << (int) aux[i];
+  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
       os << "MonitorConcWdErrCnt="
-	 << firmware->getUInt32(firmware->_monitorConcWdErrSV) << std::endl;
+   << firmware->getUInt32(firmware->_monitorConcWdErrSV) << std::endl;
 
       os << "MonitorConcStallErrCnt="
-	 << firmware->getUInt32(firmware->_monitorConcStallErrSV) << std::endl;
+   << firmware->getUInt32(firmware->_monitorConcStallErrSV) << std::endl;
 
       os << "MonitorConcExtRxErrCnt="
-	 << firmware->getUInt32(firmware->_monitorConcExtRxErrSV) << std::endl;
+   << firmware->getUInt32(firmware->_monitorConcExtRxErrSV) << std::endl;
 
       os << "TimeoutErrStatus="
-	 << firmware->getUInt32(firmware->_timeoutErrStatusSV) << std::endl;
+   << firmware->getUInt32(firmware->_timeoutErrStatusSV) << std::endl;
 
       os << "TimeoutEnable=";
       if (firmware->getBoolU64(firmware->_timeoutEnableSV)) os << "Enabled"; else os << "Disabled";
       os << std::endl;
 
       os << "TimeoutTime="
-	 << firmware->getUInt32(firmware->_timeoutTimeSV) << " usec"  << std::endl;
+   << firmware->getUInt32(firmware->_timeoutTimeSV) << " usec"  << std::endl;
       firmware->_timeoutTimeSV->setVal(7);
 
       os << "TimeoutMsgVer="
-	 << firmware->getUInt32(firmware->_timeoutMsgVerSV) << std::endl;
+   << firmware->getUInt32(firmware->_timeoutMsgVerSV) << std::endl;
 
       os << "TimoutErrIndex=";
       uint32_t aux32_32[32];
       for (uint32_t i = 0; i < 32; ++i) aux32_32[i]=0;
       firmware->_timeoutErrIndexSV->getVal(aux32_32, 32);
       for (uint32_t i = 0; i < 32; ++i) {
-	os << "0x" << std::hex << aux32_32[i] << std::dec;
-	if (i == 32 - 1) os << "]"; else os << ", ";
+  os << "0x" << std::hex << aux32_32[i] << std::dec;
+  if (i == 32 - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -855,8 +855,8 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       for (uint32_t i = 0; i < 32; ++i) aux32_32[i]=0;
       firmware->_timeoutMaskSV->getVal(aux32_32, 32);
       for (uint32_t i = 0; i < 32; ++i) {
-	os << "0x" << std::hex << aux32_32[i] << std::dec;
-	if (i == 32 - 1) os << "]"; else os << ", ";
+  os << "0x" << std::hex << aux32_32[i] << std::dec;
+  if (i == 32 - 1) os << "]"; else os << ", ";
       }
       os << std::endl;
 
@@ -865,10 +865,10 @@ std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
       os << std::endl;
 
       os << "SoftwareWdTime="
-	 << firmware->getUInt32(firmware->_swWdTimeSV) << std::endl;
+   << firmware->getUInt32(firmware->_swWdTimeSV) << std::endl;
 
       os << "EvaluationTimeStamp="
-	 << firmware->getUInt32(firmware->_evaluationTimeStampSV) << std::endl;
+   << firmware->getUInt32(firmware->_evaluationTimeStampSV) << std::endl;
 
     } catch (IOError &e) {
       std::cout << "Exception Info: " << e.getInfo() << std::endl;

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -773,7 +773,8 @@ int64_t Firmware::readPCChangeStream(uint8_t *buffer, uint32_t size, uint64_t ti
     try
     {
         ret =  _pcChangeStreamSV->read(buffer, size, CTimeout(timeout));
-    } catch (CPSWError& e)
+    }
+    catch (CPSWError& e)
     {
        std::cerr << "Failed to read the power class change stream exception: " << e.getInfo() << std::endl;
        ret = 0;

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -22,574 +22,685 @@ static Logger *firmwareLogger;
 // class asynchronous message (defined in the pc_counter_t structure)
 // Note: the method that print them, assumens that the longer string
 // is 12 char long.
-const std::vector<std::string> Firmware::PcChangePacketFlagsLabels = {
-  "MonReady",     // Bit  0
-  "ExtRxErr",     // Bit  1
-  "RxErr",        // Bit  2
-  "Pause",        // Bit  3
-  "Ovfl",         // Bit  4
-  "Drop",         // Bit  5
-  "ConWdErr2",    // Bit  6
-  "ConWdErr1",    // Bit  7
-  "ConWdErr0",    // Bit  8
-  "ConStallErr2", // Bit  9
-  "ConStallErr1", // Bit 10
-  "ConStallErr0", // Bit 11
-  "TimeoutErr",   // Bit 12
-  "SwErr",        // Bit 13
-  "Enables"       // Bit 14
-  // Bit 15 is not used at the moment
+const std::vector<std::string> Firmware::PcChangePacketFlagsLabels =
+{
+    "MonReady",     // Bit  0
+    "ExtRxErr",     // Bit  1
+    "RxErr",        // Bit  2
+    "Pause",        // Bit  3
+    "Ovfl",         // Bit  4
+    "Drop",         // Bit  5
+    "ConWdErr2",    // Bit  6
+    "ConWdErr1",    // Bit  7
+    "ConWdErr0",    // Bit  8
+    "ConStallErr2", // Bit  9
+    "ConStallErr1", // Bit 10
+    "ConStallErr0", // Bit 11
+    "TimeoutErr",   // Bit 12
+    "SwErr",        // Bit 13
+    "Enables"       // Bit 14
+    // Bit 15 is not used at the moment
 };
 
 #ifdef FW_ENABLED
 Firmware::Firmware()
-  {
+{
 #if defined(LOG_ENABLED) && !defined(LOG_STDOUT)
-  firmwareLogger = Loggers::getLogger("FIRMWARE");
-  LOG_TRACE("FIRMWARE", "Created Firmware");
+    firmwareLogger = Loggers::getLogger("FIRMWARE");
+    LOG_TRACE("FIRMWARE", "Created Firmware");
 #endif
-  for (uint32_t i = 0; i < FW_NUM_APPLICATION_MASKS_WORDS; ++i) {
-    _applicationTimeoutMaskBuffer[i] = 0;
-    _applicationTimeoutErrorBuffer[i] = 0;
-  }
-  _applicationTimeoutMaskBitSet = reinterpret_cast<ApplicationBitMaskSet *>(_applicationTimeoutMaskBuffer);
-  _applicationTimeoutErrorBitSet = reinterpret_cast<ApplicationBitMaskSet *>(_applicationTimeoutErrorBuffer);
+    for (uint32_t i = 0; i < FW_NUM_APPLICATION_MASKS_WORDS; ++i)
+    {
+        _applicationTimeoutMaskBuffer[i] = 0;
+        _applicationTimeoutErrorBuffer[i] = 0;
+    }
+    _applicationTimeoutMaskBitSet = reinterpret_cast<ApplicationBitMaskSet *>(_applicationTimeoutMaskBuffer);
+    _applicationTimeoutErrorBitSet = reinterpret_cast<ApplicationBitMaskSet *>(_applicationTimeoutErrorBuffer);
 }
 
-Firmware::~Firmware() {
-  setSoftwareEnable(false);
-  setEnable(false);
+Firmware::~Firmware()
+{
+    setSoftwareEnable(false);
+    setEnable(false);
 }
 
-int Firmware::createRoot(std::string yamlFileName) {
-  Hub hub = IPath::loadYamlFile(yamlFileName.c_str(), "NetIODev")->origin();
-  _root = IPath::create(hub);
-  return 0;
+int Firmware::createRoot(std::string yamlFileName)
+{
+    Hub hub = IPath::loadYamlFile(yamlFileName.c_str(), "NetIODev")->origin();
+    _root = IPath::create(hub);
+    return 0;
 }
 
-Path Firmware::getRoot() {
-  return _root;
+Path Firmware::getRoot()
+{
+    return _root;
 }
 
-void Firmware::setRoot(Path root) {
-  _root = root;
+void Firmware::setRoot(Path root)
+{
+    _root = root;
 }
 
 // TODO: separate yaml loading and scalval creation into two funcs - so can call yamlloader
-int Firmware::createRegisters() {
-  uint8_t gitHash[21];
+int Firmware::createRegisters()
+{
+    uint8_t gitHash[21];
 
-  if (!_root) {
-    return 1;
-  }
+    if (!_root)
+        return 1;
 
-  std::string base = "/mmio";
-  std::string axi = "/AmcCarrierCore/AxiVersion";
-  std::string mps = "/MpsCentralApplication";
-  std::string core = "/MpsCentralNodeCore";
-  std::string config = "/MpsCentralNodeConfig";
+    std::string base = "/mmio";
+    std::string axi = "/AmcCarrierCore/AxiVersion";
+    std::string mps = "/MpsCentralApplication";
+    std::string core = "/MpsCentralNodeCore";
+    std::string config = "/MpsCentralNodeConfig";
 
-  std::string name;
+    std::string name;
 
-  try {
-    name = base + axi + "/FpgaVersion";
-    _fpgaVersionSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+    try
+    {
+        name = base + axi + "/FpgaVersion";
+        _fpgaVersionSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + axi + "/BuildStamp";
-    _buildStampSV  = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + axi + "/BuildStamp";
+        _buildStampSV  = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + axi + "/GitHash";
-    _gitHashSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + axi + "/GitHash";
+        _gitHashSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/SwHeartbeat";
-    _swHeartbeatCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/SwHeartbeat";
+        _swHeartbeatCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/EvalLatchClear";
-    _evalLatchClearCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/EvalLatchClear";
+        _evalLatchClearCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/Enable";
-    _enableSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/Enable";
+        _enableSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwareEnable";
-    _swEnableSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwareEnable";
+        _swEnableSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/SoftwareClear";
-    _swClearSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/SoftwareClear";
+        _swClearSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/SoftwareLossError";
-    _swLossErrorSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/SoftwareLossError";
+        _swLossErrorSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/SoftwareLossCnt";
-    _swLossCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/SoftwareLossCnt";
+        _swLossCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwareBwidthCnt";
-    _txClkCntSV = IScalVal_RO::create (_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwareBwidthCnt";
+        _txClkCntSV = IScalVal_RO::create (_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/BeamIntTime";
-    _beamIntTimeSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/BeamIntTime";
+        _beamIntTimeSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/BeamMinPeriod";
-    _beamMinPeriodSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/BeamMinPeriod";
+        _beamMinPeriodSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/BeamIntCharge";
-    _beamIntChargeSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/BeamIntCharge";
+        _beamIntChargeSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/BeamFaultReason";
-    _beamFaultReasonSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/BeamFaultReason";
+        _beamFaultReasonSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/BeamFaultEn";
-    _beamFaultEnSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/BeamFaultEn";
+        _beamFaultEnSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/EvalLatchClear";
-    _evalLatchClearCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/EvalLatchClear";
+        _evalLatchClearCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/MonErrClear";
-    _monErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/MonErrClear";
+        _monErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/SwErrClear";
-    _swErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/SwErrClear";
+        _swErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core  + "/BeamFaultClr";
-    _beamFaultClrSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core  + "/BeamFaultClr";
+        _beamFaultClrSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/EvaluationSwPowerLevel";
-    _swMitigationSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/EvaluationSwPowerLevel";
+        _swMitigationSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/EvaluationFwPowerLevel";
-    _fwMitigationSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/EvaluationFwPowerLevel";
+        _fwMitigationSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/EvaluationLatchedPowerLevel";
-    _latchedMitigationSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/EvaluationLatchedPowerLevel";
+        _latchedMitigationSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/EvaluationPowerLevel";
-    _mitigationSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/EvaluationPowerLevel";
+        _mitigationSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SwitchConfig";
-    _switchConfigCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SwitchConfig";
+        _switchConfigCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/ToErrClear";
-    _toErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/ToErrClear";
+        _toErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MoConcErrClear";
-    _moConcErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MoConcErrClear";
+        _moConcErrClearCmd = ICommand::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorReady";
-    _monitorReadySV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorReady";
+        _monitorReadySV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorRxErrCnt";
-    _monitorRxErrorCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorRxErrCnt";
+        _monitorRxErrorCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorPauseCnt";
-    _monitorPauseCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorPauseCnt";
+        _monitorPauseCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorOvflCnt";
-    _monitorOvflCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorOvflCnt";
+        _monitorOvflCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorDropCnt";
-    _monitorDropCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorDropCnt";
+        _monitorDropCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorConcWdErr";
-    _monitorConcWdErrSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorConcWdErr";
+        _monitorConcWdErrSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorConcStallErr";
-    _monitorConcStallErrSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorConcStallErr";
+        _monitorConcStallErrSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/MonitorConcExtRxErr";
-    _monitorConcExtRxErrSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/MonitorConcExtRxErr";
+        _monitorConcExtRxErrSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/TimeoutEnable";
-    _timeoutEnableSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutEnable";
+        _timeoutEnableSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/TimeoutClear";
-    _timeoutClearSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutClear";
+        _timeoutClearSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/TimeoutTime";
-    _timeoutTimeSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutTime";
+        _timeoutTimeSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/TimeoutMask";
-    _timeoutMaskSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutMask";
+        _timeoutMaskSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    // Initialize timeout mask to zero
-    writeAppTimeoutMask();
+        // Initialize timeout mask to zero
+        writeAppTimeoutMask();
 
-    name = base + mps + core + "/TimeoutErrStatus";
-    _timeoutErrStatusSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutErrStatus";
+        _timeoutErrStatusSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/TimeoutErrIndex";
-    _timeoutErrIndexSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutErrIndex";
+        _timeoutErrIndexSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/TimeoutMsgVer";
-    _timeoutMsgVerSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/TimeoutMsgVer";
+        _timeoutMsgVerSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/EvaluationEnable";
-    _evaluationEnableSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/EvaluationEnable";
+        _evaluationEnableSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/EvaluationTimeStamp";
-    _evaluationTimeStampSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/EvaluationTimeStamp";
+        _evaluationTimeStampSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwareWdTime";
-    _swWdTimeSV = IScalVal::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwareWdTime";
+        _swWdTimeSV = IScalVal::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwareBusy";
-    _swBusySV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwareBusy";
+        _swBusySV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwarePause";
-    _swPauseSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwarePause";
+        _swPauseSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwareWdError";
-    _swWdErrorSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwareWdError";
+        _swWdErrorSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = base + mps + core + "/SoftwareOvflCnt";
-    _swOvflCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
+        name = base + mps + core + "/SoftwareOvflCnt";
+        _swOvflCntSV = IScalVal_RO::create(_root->findByName(name.c_str()));
 
-    name = "/Stream0";
-    _updateStreamSV = IStream::create(_root->findByName(name.c_str()));
+        name = "/Stream0";
+        _updateStreamSV = IStream::create(_root->findByName(name.c_str()));
 
-    name = "/Stream1";
-    _pcChangeStreamSV = IStream::create(_root->findByName(name.c_str()));
+        name = "/Stream1";
+        _pcChangeStreamSV = IStream::create(_root->findByName(name.c_str()));
 
-    // ScalVal for configuration
-    for (uint32_t i = 0; i < FW_NUM_APPLICATIONS; ++i) {
-      std::stringstream appId;
-      appId << "/AppId" << i;
-      name = base + mps + config + appId.str();
-      _configSV[i] = IScalVal::create(_root->findByName(name.c_str()));
+        // ScalVal for configuration
+        for (uint32_t i = 0; i < FW_NUM_APPLICATIONS; ++i)
+        {
+            std::stringstream appId;
+            appId << "/AppId" << i;
+            name = base + mps + config + appId.str();
+            _configSV[i] = IScalVal::create(_root->findByName(name.c_str()));
+        }
     }
-  } catch (NotFoundError &e) {
-    throw(CentralNodeException("ERROR: Failed to find " + name));
-  } catch (InterfaceNotImplementedError &e) {
-    throw(CentralNodeException("ERROR: Wrong interface for " + name));
-  }
+    catch (NotFoundError &e)
+    {
+        throw(CentralNodeException("ERROR: Failed to find " + name));
+    }
+    catch (InterfaceNotImplementedError &e)
+    {
+        throw(CentralNodeException("ERROR: Wrong interface for " + name));
+    }
 
-  if (_beamIntTimeSV->getNelms() != FW_NUM_BEAM_CLASSES) {
-    throw(CentralNodeException("ERROR: Invalid number of beam classes (BeamIntTime)"));
-  }
-  if (_beamMinPeriodSV->getNelms() != FW_NUM_BEAM_CLASSES) {
-    throw(CentralNodeException("ERROR: Invalid number of beam classes (BeamMinPeriod)"));
-  }
-  if (_beamIntChargeSV->getNelms() != FW_NUM_BEAM_CLASSES) {
-    throw(CentralNodeException("ERROR: Invalid number of beam classes (BeamIntCharge)"));
-  }
+    if (_beamIntTimeSV->getNelms() != FW_NUM_BEAM_CLASSES)
+        throw(CentralNodeException("ERROR: Invalid number of beam classes (BeamIntTime)"));
+    if (_beamMinPeriodSV->getNelms() != FW_NUM_BEAM_CLASSES)
+        throw(CentralNodeException("ERROR: Invalid number of beam classes (BeamMinPeriod)"));
+    if (_beamIntChargeSV->getNelms() != FW_NUM_BEAM_CLASSES)
+        throw(CentralNodeException("ERROR: Invalid number of beam classes (BeamIntCharge)"));
 
+    // Read some registers that are static
+    try
+    {
+        _fpgaVersionSV->getVal(&fpgaVersion);
+        _buildStampSV->getVal(buildStamp, sizeof(buildStamp)/sizeof(buildStamp[0]));
+        _gitHashSV->getVal(gitHash, sizeof(gitHash)/sizeof(gitHash[0]));
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on createRegisters()" << std::endl;
+    }
 
-  // Read some registers that are static
-  try {
-    _fpgaVersionSV->getVal(&fpgaVersion);
-    _buildStampSV->getVal(buildStamp, sizeof(buildStamp)/sizeof(buildStamp[0]));
-    _gitHashSV->getVal(gitHash, sizeof(gitHash)/sizeof(gitHash[0]));
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on createRegisters()" << std::endl;
-  }
+    for (int i = 0; i < 20; i++)
+        sprintf(&gitHashString[i], "%X", gitHash[i]);
+    gitHashString[20] = 0;
 
-  for (int i = 0; i < 20; i++) {
-    sprintf(&gitHashString[i], "%X", gitHash[i]);
-  }
-  gitHashString[20] = 0;
-
-  return 0;
+    return 0;
 }
 
-void Firmware::writeAppTimeoutMask() {
-  try {
-    _timeoutMaskSV->setVal(&_applicationTimeoutMaskBuffer[0], FW_NUM_APPLICATION_MASKS_WORDS);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on writeAppTimeoutMask()" << std::endl;
-  }
+void Firmware::writeAppTimeoutMask()
+{
+    try
+    {
+        _timeoutMaskSV->setVal(&_applicationTimeoutMaskBuffer[0], FW_NUM_APPLICATION_MASKS_WORDS);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on writeAppTimeoutMask()" << std::endl;
+    }
 }
 
-void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable) {
-  if (appId < FW_NUM_APPLICATION_MASKS) {
-    _applicationTimeoutMaskBitSet->set(appId, enable);
-  }
+void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable)
+{
+    if (appId < FW_NUM_APPLICATION_MASKS)
+        _applicationTimeoutMaskBitSet->set(appId, enable);
 }
 
-void Firmware::getAppTimeoutStatus() {
-  try {
-    _timeoutErrIndexSV->getVal(&_applicationTimeoutErrorBuffer[0], FW_NUM_APPLICATION_MASKS_WORDS);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getAppTimeoutStatus()" << std::endl;
-  }
-
+void Firmware::getAppTimeoutStatus()
+{
+    try
+    {
+        _timeoutErrIndexSV->getVal(&_applicationTimeoutErrorBuffer[0], FW_NUM_APPLICATION_MASKS_WORDS);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getAppTimeoutStatus()" << std::endl;
+    }
 }
 
 // @return true (bit is set) if there is timeout error, false if not (bit reset)
-bool Firmware::getAppTimeoutStatus(uint32_t appId) {
-  if (appId < FW_NUM_APPLICATION_MASKS) {
-    return (*_applicationTimeoutErrorBitSet)[appId];
-  }
-  return true;
+bool Firmware::getAppTimeoutStatus(uint32_t appId)
+{
+    if (appId < FW_NUM_APPLICATION_MASKS)
+        return (*_applicationTimeoutErrorBitSet)[appId];
+
+    return true;
 }
 
-void Firmware::setBoolU64(ScalVal reg, bool enable) {
-  try {
+void Firmware::setBoolU64(ScalVal reg, bool enable)
+{
+    try
+    {
+        uint64_t value = 0;
+        if (enable) value = 1;
+        reg->setVal(value);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error setBoolU64(reg, bool)" << std::endl;
+    }
+}
+
+bool Firmware::getBoolU64(ScalVal reg)
+{
+    uint64_t value;
+    try
+    {
+        reg->getVal(&value);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getBoolU64(reg)" << std::endl;
+        return false;
+    }
+
+    if (value == 0)
+        return false;
+    else
+        return true;
+}
+
+uint64_t Firmware::getUInt64(ScalVal_RO reg)
+{
     uint64_t value = 0;
-    if (enable) value = 1;
-    reg->setVal(value);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error setBoolU64(reg, bool)" << std::endl;
-  }
+    try
+    {
+        reg->getVal(&value);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getUInt64(reg)" << std::endl;
+    }
+    return value;
 }
 
-bool Firmware::getBoolU64(ScalVal reg) {
-  uint64_t value;
-  try {
-    reg->getVal(&value);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getBoolU64(reg)" << std::endl;
-    return false;
-  }
-
-  if (value == 0) return false; else return true;
+uint32_t Firmware::getUInt32(ScalVal_RO reg)
+{
+    uint32_t value = 0;
+    try
+    {
+        reg->getVal(&value);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getUInt32(reg)" << std::endl;
+    }
+    return value;
 }
 
-uint64_t Firmware::getUInt64(ScalVal_RO reg) {
-  uint64_t value = 0;
-  try {
-    reg->getVal(&value);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getUInt64(reg)" << std::endl;
-  }
-  return value;
+uint32_t Firmware::getUInt32(ScalVal reg)
+{
+    uint32_t value = 0;
+    try
+    {
+        reg->getVal(&value);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getUInt32(reg)" << std::endl;
+    }
+    return value;
 }
 
-uint32_t Firmware::getUInt32(ScalVal_RO reg) {
-  uint32_t value = 0;
-  try {
-    reg->getVal(&value);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getUInt32(reg)" << std::endl;
-  }
-  return value;
+uint8_t Firmware::getUInt8(ScalVal_RO reg)
+{
+    uint8_t value = 0;
+    try
+    {
+        reg->getVal(&value);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getUInt8(reg)" << std::endl;
+    }
+    return value;
 }
 
-uint32_t Firmware::getUInt32(ScalVal reg) {
-  uint32_t value = 0;
-  try {
-    reg->getVal(&value);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getUInt32(reg)" << std::endl;
-  }
-  return value;
+void Firmware::setEnable(bool enable)
+{
+    setBoolU64(_enableSV, enable);
 }
 
-uint8_t Firmware::getUInt8(ScalVal_RO reg) {
-  uint8_t value = 0;
-  try {
-    reg->getVal(&value);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getUInt8(reg)" << std::endl;
-  }
-  return value;
+bool Firmware::getEnable()
+{
+    return getBoolU64(_enableSV);
 }
 
-void Firmware::setEnable(bool enable) {
-  setBoolU64(_enableSV, enable);
+uint32_t Firmware::getSoftwareClockCount()
+{
+    return getUInt32(_txClkCntSV);
 }
 
-bool Firmware::getEnable() {
-  return getBoolU64(_enableSV);
+uint8_t Firmware::getSoftwareLossError()
+{
+    return getUInt8(_swLossErrorSV);
 }
 
-uint32_t Firmware::getSoftwareClockCount() {
-  return getUInt32(_txClkCntSV);
+uint32_t Firmware::getSoftwareLossCount()
+{
+    return getUInt32(_swLossCntSV);
 }
 
-uint8_t Firmware::getSoftwareLossError() {
-  return getUInt8(_swLossErrorSV);
+void Firmware::setEvaluationEnable(bool enable)
+{
+    setBoolU64(_evaluationEnableSV, enable);
 }
 
-uint32_t Firmware::getSoftwareLossCount() {
-  return getUInt32(_swLossCntSV);
+bool Firmware::getEvaluationEnable()
+{
+    return getBoolU64(_evaluationEnableSV);
 }
 
-void Firmware::setEvaluationEnable(bool enable) {
-  setBoolU64(_evaluationEnableSV, enable);
-}
-
-bool Firmware::getEvaluationEnable() {
-  return getBoolU64(_evaluationEnableSV);
-}
-
-void Firmware::setTimeoutEnable(bool enable) {
-  setBoolU64(_timeoutEnableSV, enable);
+void Firmware::setTimeoutEnable(bool enable)
+{
+    setBoolU64(_timeoutEnableSV, enable);
 }
 
 bool Firmware::getTimeoutEnable() {
   return getBoolU64(_timeoutEnableSV);
 }
 
-void Firmware::setTimingCheckEnable(bool enable) {
-  setBoolU64(_beamFaultEnSV, enable);
+void Firmware::setTimingCheckEnable(bool enable)
+{
+    setBoolU64(_beamFaultEnSV, enable);
 }
 
-void Firmware::setSoftwareEnable(bool enable) {
-  setBoolU64(_swEnableSV, enable);
+void Firmware::setSoftwareEnable(bool enable)
+{
+    setBoolU64(_swEnableSV, enable);
 }
 
-bool Firmware::getSoftwareEnable() {
-  return getBoolU64(_swEnableSV);
+bool Firmware::getSoftwareEnable()
+{
+    return getBoolU64(_swEnableSV);
 }
 
-bool Firmware::getTimingCheckEnable() {
-  return getBoolU64(_beamFaultEnSV);
+bool Firmware::getTimingCheckEnable()
+{
+    return getBoolU64(_beamFaultEnSV);
 }
 
-void Firmware::softwareClear() {
-  setBoolU64(_swClearSV, true);
-  setBoolU64(_swClearSV, false);
+void Firmware::softwareClear()
+{
+    setBoolU64(_swClearSV, true);
+    setBoolU64(_swClearSV, false);
 }
 
-uint32_t Firmware::getFaultReason() {
-  return getUInt32(_beamFaultReasonSV);
+uint32_t Firmware::getFaultReason()
+{
+    return getUInt32(_beamFaultReasonSV);
 }
 
-void Firmware::getFirmwareMitigation(uint32_t *fwMitigation) {
-  try {
-    _fwMitigationSV->getVal(fwMitigation, 2);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getFirmwareMitigation()" << std::endl;
-  }
-}
-
-void Firmware::getSoftwareMitigation(uint32_t *swMitigation) {
-  try {
-    _swMitigationSV->getVal(swMitigation, 2);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getSoftwareMitigation()" << std::endl;
-  }
-}
-
-void Firmware::getMitigation(uint32_t *mitigation) {
-  try {
-    _mitigationSV->getVal(mitigation, 2);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getMitigation()" << std::endl;
-  }
-}
-
-void Firmware::getLatchedMitigation(uint32_t *latchedMitigation) {
-  try {
-    _latchedMitigationSV->getVal(latchedMitigation, 2);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on getLatchedMitigation()" << std::endl;
-  }
-}
-
-void Firmware::extractMitigation(uint32_t *compressed, uint8_t *expanded) {
-  for (int i = 0; i < 8; ++i) {
-    expanded[i] = (uint8_t)((compressed[0] >> (4 * i)) & 0xF);
-  }
-
-  for (int i = 0; i < 8; ++i) {
-    expanded[i+8] = (uint8_t)((compressed[1] >> (4 * i)) & 0xF);
-  }
-}
-
-void Firmware::writeConfig(uint32_t appNumber, uint8_t *config, uint32_t size) {
-  uint32_t *config32 = reinterpret_cast<uint32_t *>(config);
-  uint32_t size32 = size / 4;
-
-  if (appNumber < FW_NUM_APPLICATIONS) {
-    try {
-      LOG_TRACE("FIRMWARE", "Writing configuration for application number #" << appNumber << " data size=" << size32);
-      _configSV[appNumber]->setVal(config32, size32);
-    } catch (InvalidArgError &e) {
-      throw(CentralNodeException("ERROR: Failed writing app configuration (InvalidArgError)."));
-    } catch (BadStatusError &e) {
-      std::cout << "Exception Info: " << e.getInfo() << std::endl;
-      throw(CentralNodeException("ERROR: Failed writing app configuration (BadStatusError)"));
-    } catch (IOError &e) {
-      std::cout << "Exception Info: " << e.getInfo() << std::endl;
-      showStats();
-      throw(CentralNodeException("ERROR: Failed writing app configuration (IOError)"));
+void Firmware::getFirmwareMitigation(uint32_t *fwMitigation)
+{
+    try
+    {
+        _fwMitigationSV->getVal(fwMitigation, 2);
     }
-  }
-
-  // Hit the switch register to enable now configuration
-  //  switchConfig();
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getFirmwareMitigation()" << std::endl;
+    }
 }
 
-bool Firmware::switchConfig() {
-  try {
-    _switchConfigCmd->execute();
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
-
+void Firmware::getSoftwareMitigation(uint32_t *swMitigation)
+{
+    try
+    {
+        _swMitigationSV->getVal(swMitigation, 2);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getSoftwareMitigation()" << std::endl;
+    }
 }
 
-bool Firmware::evalLatchClear() {
-  try {
-    _evalLatchClearCmd->execute();
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
+void Firmware::getMitigation(uint32_t *mitigation)
+{
+    try
+    {
+        _mitigationSV->getVal(mitigation, 2);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getMitigation()" << std::endl;
+    }
 }
 
-bool Firmware::monErrClear() {
-  try {
-    _monErrClearCmd->execute();
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
+void Firmware::getLatchedMitigation(uint32_t *latchedMitigation)
+{
+    try
+    {
+        _latchedMitigationSV->getVal(latchedMitigation, 2);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on getLatchedMitigation()" << std::endl;
+    }
 }
 
-bool Firmware::swErrClear() {
-  try {
-    _swErrClearCmd->execute();
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
+void Firmware::extractMitigation(uint32_t *compressed, uint8_t *expanded)
+{
+    for (int i = 0; i < 8; ++i)
+        expanded[i] = (uint8_t)((compressed[0] >> (4 * i)) & 0xF);
+
+    for (int i = 0; i < 8; ++i)
+        expanded[i+8] = (uint8_t)((compressed[1] >> (4 * i)) & 0xF);
 }
 
-bool Firmware::toErrClear() {
-  try {
-    _toErrClearCmd->execute();
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
+void Firmware::writeConfig(uint32_t appNumber, uint8_t *config, uint32_t size)
+{
+    uint32_t *config32 = reinterpret_cast<uint32_t *>(config);
+    uint32_t size32 = size / 4;
+
+    if (appNumber < FW_NUM_APPLICATIONS)
+    {
+        try
+        {
+            LOG_TRACE("FIRMWARE", "Writing configuration for application number #" << appNumber << " data size=" << size32);
+            _configSV[appNumber]->setVal(config32, size32);
+        }
+        catch (InvalidArgError &e)
+        {
+            throw(CentralNodeException("ERROR: Failed writing app configuration (InvalidArgError)."));
+        }
+        catch (BadStatusError &e)
+        {
+            std::cout << "Exception Info: " << e.getInfo() << std::endl;
+            throw(CentralNodeException("ERROR: Failed writing app configuration (BadStatusError)"));
+        }
+        catch (IOError &e)
+        {
+            std::cout << "Exception Info: " << e.getInfo() << std::endl;
+            showStats();
+            throw(CentralNodeException("ERROR: Failed writing app configuration (IOError)"));
+        }
+    }
+
+    // Hit the switch register to enable now configuration
+    //  switchConfig();
 }
 
-bool Firmware::moConcErrClear() {
-  try {
-    _moConcErrClearCmd->execute();
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
+bool Firmware::switchConfig()
+{
+    try
+    {
+        _switchConfigCmd->execute();
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
 }
 
-bool Firmware::beamFaultClear() {
-  try {
-    uint64_t val = 1;
-    _beamFaultClrSV->setVal(val);
-    val = 0;
-    _beamFaultClrSV->setVal(val);
-  } catch (IOError &e) {
-    std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    return false;
-  }
-  return true;
+bool Firmware::evalLatchClear()
+{
+    try
+    {
+        _evalLatchClearCmd->execute();
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
 }
 
-bool Firmware::clearAll() {
-  return evalLatchClear() ||
-    monErrClear() ||
-    swErrClear() ||
-    toErrClear() ||
-    beamFaultClear() ||
-    moConcErrClear();
+bool Firmware::monErrClear()
+{
+    try
+    {
+        _monErrClearCmd->execute();
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool Firmware::swErrClear()
+{
+    try
+    {
+        _swErrClearCmd->execute();
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool Firmware::toErrClear()
+{
+    try
+    {
+        _toErrClearCmd->execute();
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool Firmware::moConcErrClear()
+{
+    try
+    {
+        _moConcErrClearCmd->execute();
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool Firmware::beamFaultClear()
+{
+    try
+    {
+        uint64_t val = 1;
+        _beamFaultClrSV->setVal(val);
+        val = 0;
+        _beamFaultClrSV->setVal(val);
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+        return false;
+    }
+    return true;
+}
+
+bool Firmware::clearAll()
+{
+    return evalLatchClear() ||
+        monErrClear() ||
+        swErrClear() ||
+        toErrClear() ||
+        beamFaultClear() ||
+        moConcErrClear();
 }
 
 /**
@@ -605,53 +716,65 @@ bool Firmware::clearAll() {
  *      999 in lower bits
  *      999 in the upper bits
  */
-void Firmware::writeTimingChecking(uint32_t time[], uint32_t period[], uint32_t charge[]) {
-  try {
-    _beamMinPeriodSV->setVal(period, FW_NUM_BEAM_CLASSES);
-    _beamIntChargeSV->setVal(charge, FW_NUM_BEAM_CLASSES);
+void Firmware::writeTimingChecking(uint32_t time[], uint32_t period[], uint32_t charge[])
+{
+    try
+    {
+        _beamMinPeriodSV->setVal(period, FW_NUM_BEAM_CLASSES);
+        _beamIntChargeSV->setVal(charge, FW_NUM_BEAM_CLASSES);
 
-    uint32_t new_time[FW_NUM_BEAM_CLASSES];
-    for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-      new_time[i] = 0;
-      if (time[i] > 1000) {
-  // Set bits 25:16 first
-  new_time[i] = time[i]/1000 - 1;
-  new_time[i] <<= 16;
-  // Set lower bits next
-  new_time[i] |= 999;
-      }
-      else {
-        if (time[i] != 0) {
-    new_time[i] = time[i];
+        uint32_t new_time[FW_NUM_BEAM_CLASSES];
+        for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+        {
+            new_time[i] = 0;
+            if (time[i] > 1000)
+            {
+                // Set bits 25:16 first
+                new_time[i] = time[i]/1000 - 1;
+                new_time[i] <<= 16;
+                // Set lower bits next
+                new_time[i] |= 999;
+            }
+            else
+            {
+                if (time[i] != 0)
+                    new_time[i] = time[i];
+            }
         }
-      }
+
+        _beamIntTimeSV->setVal(new_time, FW_NUM_BEAM_CLASSES);
+
     }
-
-    _beamIntTimeSV->setVal(new_time, FW_NUM_BEAM_CLASSES);
-
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on writeTimingChecking()" << std::endl;
-  }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on writeTimingChecking()" << std::endl;
+    }
 }
 
-uint64_t Firmware::readUpdateStream(uint8_t *buffer, uint32_t size, uint64_t timeout) {
-  uint64_t val = 0;
-  try {
-    val = _updateStreamSV->read(buffer, size, CTimeout(timeout));
-  } catch (IOError &e) {
-    std::cout << "Failed to read update stream exception: " << e.getInfo() << std::endl;
-    val = 0;
-  }
-  return val;
+uint64_t Firmware::readUpdateStream(uint8_t *buffer, uint32_t size, uint64_t timeout)
+{
+    uint64_t val = 0;
+    try
+    {
+        val = _updateStreamSV->read(buffer, size, CTimeout(timeout));
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Failed to read update stream exception: " << e.getInfo() << std::endl;
+        val = 0;
+    }
+    return val;
 }
 
 int64_t Firmware::readPCChangeStream(uint8_t *buffer, uint32_t size, uint64_t timeout) const
 {
     int64_t ret {0};
 
-    try {
+    try
+    {
         ret =  _pcChangeStreamSV->read(buffer, size, CTimeout(timeout));
-    } catch (CPSWError& e) {
+    } catch (CPSWError& e)
+    {
        std::cerr << "Failed to read the power class change stream exception: " << e.getInfo() << std::endl;
        ret = 0;
     }
@@ -659,221 +782,271 @@ int64_t Firmware::readPCChangeStream(uint8_t *buffer, uint32_t size, uint64_t ti
     return ret;
 }
 
-void Firmware::writeMitigation(uint32_t *mitigation) {
-  //DEBUG
-  //  mitigation[0] = 0x55667788;
-  //  mitigation[1] = 0x11223344;
-  //DEBUG
-  try {
-    _swMitigationSV->setVal(mitigation, 2);
-  } catch (IOError &e) {
-    std::cerr << "ERROR: CPSW I/O Error on writeMitigation()" << std::endl;
-  }
+void Firmware::writeMitigation(uint32_t *mitigation)
+{
+    //DEBUG
+    //  mitigation[0] = 0x55667788;
+    //  mitigation[1] = 0x11223344;
+    //DEBUG
+    try
+    {
+        _swMitigationSV->setVal(mitigation, 2);
+    }
+    catch (IOError &e)
+    {
+        std::cerr << "ERROR: CPSW I/O Error on writeMitigation()" << std::endl;
+    }
 }
 
-void Firmware::showStats() {
-  Children rootsChildren = _root->origin()->getChildren();
-  std::vector<Child>::const_iterator it;
+void Firmware::showStats()
+{
+    Children rootsChildren = _root->origin()->getChildren();
+    std::vector<Child>::const_iterator it;
 
-  for ( it = rootsChildren->begin(); it != rootsChildren->end(); ++it ) {
-    (*it)->dump();
-  }
+    for ( it = rootsChildren->begin(); it != rootsChildren->end(); ++it )
+        (*it)->dump();
 }
 
-std::ostream & operator<<(std::ostream &os, Firmware * const firmware) {
+std::ostream & operator<<(std::ostream &os, Firmware * const firmware)
+{
     os << "=== MpsCentralNode ===" << std::endl;
     os << "FPGA version=" << firmware->fpgaVersion << std::endl;
     os << "Build stamp=\"" << firmware->buildStamp << "\"" << std::endl;
     os << "Git hash=\"" << firmware->gitHashString << "\"" << std::endl;
 
-    try {
-      os << "Enable=";
-      if (firmware->getEnable()) os << "Enabled"; else os << "Disabled";
-      os << std::endl;
+    try
+    {
+        os << "Enable=";
+        if (firmware->getEnable()) os << "Enabled"; else os << "Disabled";
+            os << std::endl;
 
-      os << "SwEnable=";
-      if (firmware->getSoftwareEnable()) os << "Enabled"; else os << "Disabled";
-      os << std::endl;
+        os << "SwEnable=";
+        if (firmware->getSoftwareEnable()) os << "Enabled"; else os << "Disabled";
+            os << std::endl;
 
-      os << "SwLossCnt=" << firmware->getSoftwareLossCount() << std::endl;
-      os << "SwLossError=" << (int) firmware->getSoftwareLossError() << std::endl;
-      os << "SwBwidthCnt=" << firmware->getSoftwareClockCount() << std::endl;
+        os << "SwLossCnt=" << firmware->getSoftwareLossCount() << std::endl;
+        os << "SwLossError=" << (int) firmware->getSoftwareLossError() << std::endl;
+        os << "SwBwidthCnt=" << firmware->getSoftwareClockCount() << std::endl;
 
-      uint32_t aux[FW_NUM_BEAM_CLASSES]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-      firmware->_beamIntTimeSV->getVal(aux, FW_NUM_BEAM_CLASSES);
-      os << "BeamIntTime=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-  os << aux[i];
-  if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        uint32_t aux[FW_NUM_BEAM_CLASSES]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        firmware->_beamIntTimeSV->getVal(aux, FW_NUM_BEAM_CLASSES);
+        os << "BeamIntTime=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+        {
+            os << aux[i];
+            if (i == FW_NUM_BEAM_CLASSES - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) aux[i]=0;
-      firmware->_beamMinPeriodSV->getVal(aux, FW_NUM_BEAM_CLASSES);
-      os << "BeamMinPeriod=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-  os << aux[i];
-  if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+            aux[i]=0;
+        firmware->_beamMinPeriodSV->getVal(aux, FW_NUM_BEAM_CLASSES);
+        os << "BeamMinPeriod=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+        {
+            os << aux[i];
+            if (i == FW_NUM_BEAM_CLASSES - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) aux[i]=0;
-      firmware->_beamIntChargeSV->getVal(aux, FW_NUM_BEAM_CLASSES);
-      os << "BeamIntCharge=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i) {
-  os << aux[i];
-  if (i == FW_NUM_BEAM_CLASSES - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+            aux[i]=0;
+        firmware->_beamIntChargeSV->getVal(aux, FW_NUM_BEAM_CLASSES);
+        os << "BeamIntCharge=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_CLASSES; ++i)
+        {
+            os << aux[i];
+            if (i == FW_NUM_BEAM_CLASSES - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      os << "BeamFaultReason=" << std::hex << "0x"
-   << firmware->getUInt32(firmware->_beamFaultReasonSV) << std::dec << std::endl;
+        os << "BeamFaultReason=" << std::hex << "0x"
+            << firmware->getUInt32(firmware->_beamFaultReasonSV) << std::dec << std::endl;
 
-      os << "BeamFaultEnable=";
-      if (firmware->getBoolU64(firmware->_beamFaultEnSV)) os << "Enabled"; else os << "Disabled";
-      os << std::endl;
+        os << "BeamFaultEnable=";
+        if (firmware->getBoolU64(firmware->_beamFaultEnSV))
+            os << "Enabled"; else os << "Disabled";
+        os << std::endl;
 
-      uint8_t aux8[FW_NUM_BEAM_DESTINATIONS]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-      uint32_t aux32[2]={0,0};
-      firmware->getMitigation(aux32);
-      //      firmware->getMitigation(aux8);
-      firmware->extractMitigation(aux32, aux8);
-      os << "Mitigation=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-  os << (int) aux8[i];
-  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        uint8_t aux8[FW_NUM_BEAM_DESTINATIONS]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        uint32_t aux32[2]={0,0};
+        firmware->getMitigation(aux32);
+        //      firmware->getMitigation(aux8);
+        firmware->extractMitigation(aux32, aux8);
+        os << "Mitigation=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+        {
+            os << (int) aux8[i];
+            if (i == FW_NUM_BEAM_DESTINATIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      firmware->getFirmwareMitigation(aux32);
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux8[i]=0;
-      //      firmware->getFirmwareMitigation(aux8);
-      firmware->extractMitigation(aux32, aux8);
-      os << "FirmwareMitigation=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-  os << (int) aux8[i];
-  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        firmware->getFirmwareMitigation(aux32);
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux8[i]=0;
+        //      firmware->getFirmwareMitigation(aux8);
+        firmware->extractMitigation(aux32, aux8);
+        os << "FirmwareMitigation=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+        {
+            os << (int) aux8[i];
+            if (i == FW_NUM_BEAM_DESTINATIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      firmware->getSoftwareMitigation(aux32);
-      os << "SoftwareMitigation=[";
-      os << std::hex << "0x" << aux32[0] << " 0x" << aux32[1] << std::dec << "]" << std::endl;
+        firmware->getSoftwareMitigation(aux32);
+        os << "SoftwareMitigation=[";
+        os << std::hex << "0x" << aux32[0] << " 0x" << aux32[1] << std::dec << "]" << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux8[i]=0;
-      //      firmware->getSoftwareMitigation(aux8);
-      firmware->extractMitigation(aux32, aux8);
-      os << "SoftwareMitigation=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-  os << (int) aux8[i];
-  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux8[i]=0;
+        //      firmware->getSoftwareMitigation(aux8);
+        firmware->extractMitigation(aux32, aux8);
+        os << "SoftwareMitigation=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+        {
+            os << (int) aux8[i];
+            if (i == FW_NUM_BEAM_DESTINATIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      firmware->getLatchedMitigation(aux32);
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux8[i]=0;
-      firmware->extractMitigation(aux32, aux8);
-      //      firmware->getLatchedMitigation(aux8);
-      os << "LatchedMitigation=[";
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) {
-  os << (int) aux8[i];
-  if (i == FW_NUM_BEAM_DESTINATIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        firmware->getLatchedMitigation(aux32);
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux8[i]=0;
+        firmware->extractMitigation(aux32, aux8);
+        //      firmware->getLatchedMitigation(aux8);
+        os << "LatchedMitigation=[";
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+        {
+            os << (int) aux8[i];
+            if (i == FW_NUM_BEAM_DESTINATIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux[i]=0;
-      firmware->_monitorRxErrorCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
-      os << "MonitorRxErrorCnt=[";
-      for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-  os << (int) aux[i];
-  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux[i]=0;
+        firmware->_monitorRxErrorCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
+        os << "MonitorRxErrorCnt=[";
+        for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i)
+        {
+            os << (int) aux[i];
+            if (i == FW_NUM_CONNECTIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux[i]=0;
-      firmware->_monitorPauseCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
-      os << "MonitorPauseCnt=[";
-      for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-  os << (int) aux[i];
-  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux[i]=0;
+        firmware->_monitorPauseCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
+        os << "MonitorPauseCnt=[";
+        for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i)
+        {
+            os << (int) aux[i];
+            if (i == FW_NUM_CONNECTIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux[i]=0;
-      firmware->_monitorOvflCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
-      os << "MonitorOvflCnt=[";
-      for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-  os << (int) aux[i];
-  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux[i]=0;
+        firmware->_monitorOvflCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
+        os << "MonitorOvflCnt=[";
+        for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i)
+        {
+            os << (int) aux[i];
+            if (i == FW_NUM_CONNECTIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i) aux[i]=0;
-      firmware->_monitorDropCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
-      os << "MonitorDropCnt=[";
-      for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i) {
-  os << (int) aux[i];
-  if (i == FW_NUM_CONNECTIONS - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        for (uint32_t i = 0; i < FW_NUM_BEAM_DESTINATIONS; ++i)
+            aux[i]=0;
+        firmware->_monitorDropCntSV->getVal(aux, FW_NUM_BEAM_DESTINATIONS);
+        os << "MonitorDropCnt=[";
+        for (uint32_t i = 0; i < FW_NUM_CONNECTIONS; ++i)
+        {
+            os << (int) aux[i];
+            if (i == FW_NUM_CONNECTIONS - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      os << "MonitorConcWdErrCnt="
-   << firmware->getUInt32(firmware->_monitorConcWdErrSV) << std::endl;
+        os << "MonitorConcWdErrCnt="
+            << firmware->getUInt32(firmware->_monitorConcWdErrSV) << std::endl;
 
-      os << "MonitorConcStallErrCnt="
-   << firmware->getUInt32(firmware->_monitorConcStallErrSV) << std::endl;
+        os << "MonitorConcStallErrCnt="
+            << firmware->getUInt32(firmware->_monitorConcStallErrSV) << std::endl;
 
-      os << "MonitorConcExtRxErrCnt="
-   << firmware->getUInt32(firmware->_monitorConcExtRxErrSV) << std::endl;
+        os << "MonitorConcExtRxErrCnt="
+            << firmware->getUInt32(firmware->_monitorConcExtRxErrSV) << std::endl;
 
-      os << "TimeoutErrStatus="
-   << firmware->getUInt32(firmware->_timeoutErrStatusSV) << std::endl;
+        os << "TimeoutErrStatus="
+            << firmware->getUInt32(firmware->_timeoutErrStatusSV) << std::endl;
 
-      os << "TimeoutEnable=";
-      if (firmware->getBoolU64(firmware->_timeoutEnableSV)) os << "Enabled"; else os << "Disabled";
-      os << std::endl;
+        os << "TimeoutEnable=";
+        if (firmware->getBoolU64(firmware->_timeoutEnableSV))
+            os << "Enabled"; else os << "Disabled";
+        os << std::endl;
 
-      os << "TimeoutTime="
-   << firmware->getUInt32(firmware->_timeoutTimeSV) << " usec"  << std::endl;
-      firmware->_timeoutTimeSV->setVal(7);
+        os << "TimeoutTime="
+            << firmware->getUInt32(firmware->_timeoutTimeSV) << " usec"  << std::endl;
+        firmware->_timeoutTimeSV->setVal(7);
 
-      os << "TimeoutMsgVer="
-   << firmware->getUInt32(firmware->_timeoutMsgVerSV) << std::endl;
+        os << "TimeoutMsgVer="
+            << firmware->getUInt32(firmware->_timeoutMsgVerSV) << std::endl;
 
-      os << "TimoutErrIndex=";
-      uint32_t aux32_32[32];
-      for (uint32_t i = 0; i < 32; ++i) aux32_32[i]=0;
-      firmware->_timeoutErrIndexSV->getVal(aux32_32, 32);
-      for (uint32_t i = 0; i < 32; ++i) {
-  os << "0x" << std::hex << aux32_32[i] << std::dec;
-  if (i == 32 - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        os << "TimoutErrIndex=";
+        uint32_t aux32_32[32];
+        for (uint32_t i = 0; i < 32; ++i)
+            aux32_32[i]=0;
+        firmware->_timeoutErrIndexSV->getVal(aux32_32, 32);
+        for (uint32_t i = 0; i < 32; ++i)
+        {
+            os << "0x" << std::hex << aux32_32[i] << std::dec;
+            if (i == 32 - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
 
-      os << "TimoutMask=";
-      for (uint32_t i = 0; i < 32; ++i) aux32_32[i]=0;
-      firmware->_timeoutMaskSV->getVal(aux32_32, 32);
-      for (uint32_t i = 0; i < 32; ++i) {
-  os << "0x" << std::hex << aux32_32[i] << std::dec;
-  if (i == 32 - 1) os << "]"; else os << ", ";
-      }
-      os << std::endl;
+        os << "TimoutMask=";
+        for (uint32_t i = 0; i < 32; ++i)
+            aux32_32[i]=0;
+        firmware->_timeoutMaskSV->getVal(aux32_32, 32);
+        for (uint32_t i = 0; i < 32; ++i)
+        {
+            os << "0x" << std::hex << aux32_32[i] << std::dec;
+            if (i == 32 - 1)
+                os << "]"; else os << ", ";
+        }
+        os << std::endl;
 
-      os << "EvaluationEnable=";
-      if (firmware->getBoolU64(firmware->_evaluationEnableSV)) os << "Enabled"; else os << "Disabled";
-      os << std::endl;
+        os << "EvaluationEnable=";
+        if (firmware->getBoolU64(firmware->_evaluationEnableSV))
+            os << "Enabled"; else os << "Disabled";
+        os << std::endl;
 
-      os << "SoftwareWdTime="
-   << firmware->getUInt32(firmware->_swWdTimeSV) << std::endl;
+        os << "SoftwareWdTime="
+            << firmware->getUInt32(firmware->_swWdTimeSV) << std::endl;
 
-      os << "EvaluationTimeStamp="
-   << firmware->getUInt32(firmware->_evaluationTimeStampSV) << std::endl;
+        os << "EvaluationTimeStamp="
+            << firmware->getUInt32(firmware->_evaluationTimeStampSV) << std::endl;
 
-    } catch (IOError &e) {
-      std::cout << "Exception Info: " << e.getInfo() << std::endl;
-    } catch (InvalidArgError &e) {
-      std::cout << "Exception Info: " << e.getInfo() << std::endl;
+    }
+    catch (IOError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
+    }
+    catch (InvalidArgError &e)
+    {
+        std::cout << "Exception Info: " << e.getInfo() << std::endl;
     }
 
     return os;

--- a/src/central_node_firmware.h
+++ b/src/central_node_firmware.h
@@ -207,7 +207,7 @@ class Firmware {
 
   uint64_t readUpdateStream(uint8_t *buffer, uint32_t size, uint64_t timeout);
   int64_t readPCChangeStream(uint8_t *buffer, uint32_t size, uint64_t timeout) const;
-  void writeMitigation(uint32_t *mitigation);
+  void writeMitigation(const std::vector<uint32_t>& mitigation);
   void writeTimingChecking(uint32_t time[], uint32_t period[], uint32_t charge[]);
 
   static Firmware &getInstance() {

--- a/src/central_node_inputs.cc
+++ b/src/central_node_inputs.cc
@@ -27,7 +27,7 @@ ApplicationUpdateBufferBitSetHalf* DbApplicationCardInput::getWasLowBuffer()
     if (!fwUpdateBuffer)
         return NULL;
 
-    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->getReadPtr()->at(wasLowBufferOffset));
+    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->at(wasLowBufferOffset));
 }
 
 ApplicationUpdateBufferBitSetHalf* DbApplicationCardInput::getWasHighBuffer()
@@ -35,7 +35,7 @@ ApplicationUpdateBufferBitSetHalf* DbApplicationCardInput::getWasHighBuffer()
     if (!fwUpdateBuffer)
         return NULL;
 
-    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->getReadPtr()->at(wasHighBufferOffset));
+    return reinterpret_cast<ApplicationUpdateBufferBitSetHalf *>(&fwUpdateBuffer->at(wasHighBufferOffset));
 }
 
 uint32_t DbApplicationCardInput::getWasLow(int channel) {
@@ -46,7 +46,7 @@ uint32_t DbApplicationCardInput::getWasHigh(int channel) {
   return (*getWasHighBuffer())[channel];
 }
 
-void DbApplicationCardInput::setUpdateBuffers(DataBuffer<uint8_t>* bufPtr, const size_t wasLowBufferOff, const size_t wasHighBufferOff) 
+void DbApplicationCardInput::setUpdateBuffers(std::vector<uint8_t>* bufPtr, const size_t wasLowBufferOff, const size_t wasHighBufferOff)
 {
     fwUpdateBuffer      = bufPtr;
     wasLowBufferOffset  = wasLowBufferOff;

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -173,7 +173,7 @@ void NonBlockingBeat::beatWriter()
 
     // Declare as real time task
     struct sched_param  param;
-    param.sched_priority = 74;
+    param.sched_priority = 87;
     if(sched_setscheduler(0, SCHED_FIFO, &param) == -1)
     {
         perror("Set priority");

--- a/src/heartbeat.cc
+++ b/src/heartbeat.cc
@@ -125,12 +125,13 @@ void BlockingBeat::printBeatReport()
 ///////////////////////////////////////
 NonBlockingBeat::NonBlockingBeat(Path root, size_t timerBufferSize)
 :
-    BeatBase      ( root, timerBufferSize ),
-    reqTimeoutCnt ( 0 ),
-    reqTimeout    ( 5 ),
-    beatReq       ( false ),
-    run           ( true ),
-    beatThread    ( std::thread( &NonBlockingBeat::beatWriter, this ) )
+    BeatBase        ( root, timerBufferSize ),
+    reqTimeoutCnt   ( 0 ),
+    reqTimeout      ( 5 ),
+    beatReqCount    ( 0 ),
+    beatReqCountMax ( 0 ),
+    run             ( true ),
+    beatThread      ( std::thread( &NonBlockingBeat::beatWriter, this ) )
 {
     if( pthread_setname_np( beatThread.native_handle(), "HeartBeat" ) )
        perror( "pthread_setname_np failed for HeartBeat thread" );
@@ -145,25 +146,26 @@ NonBlockingBeat::~NonBlockingBeat()
 
 void NonBlockingBeat::clear()
 {
-    // Wait for any heartbeat generation in progress
-    std::unique_lock<std::mutex> lock(beatMutex);
-    beatCondVar.wait( lock, std::bind(&NonBlockingBeat::predN, this) );
-
+    {
+        std::lock_guard<std::mutex> lock(beatMutex);
+        beatReqCountMax = 0;
+        reqTimeoutCnt = 0;
+    }
     defaultClear();
-
-    reqTimeoutCnt = 0;
 }
 
 void NonBlockingBeat::beat()
 {
-    // Wait for any heartbeat generation in progress
     {
-        std::unique_lock<std::mutex> lock(beatMutex);
-        beatCondVar.wait( lock, std::bind(&NonBlockingBeat::predN, this) );
+        std::lock_guard<std::mutex> lock(beatMutex);
+        // Increase the request counter
+        ++beatReqCount;
+
+        // Keep track of the maximum number of requests without handling
+        if (beatReqCount > beatReqCountMax)
+            beatReqCountMax = beatReqCount;
     }
 
-    std::unique_lock<std::mutex> lock(beatMutex);
-    beatReq = true;
     beatCondVar.notify_one();
 }
 
@@ -186,19 +188,14 @@ void NonBlockingBeat::beatWriter()
         std::unique_lock<std::mutex> lock(beatMutex);
         if (beatCondVar.wait_for(lock, std::chrono::milliseconds(reqTimeout), std::bind(&NonBlockingBeat::pred, this)))
         {
-            defaultBeat();
-
-            // Notify that we are done with the heartbeat generation.
-            // Manual unlocking is done before notifying, to avoid waking up
-            // the waiting thread only to block again (see notify_one for details)
-            beatReq = false;
+            --beatReqCount;
             lock.unlock();
-            beatCondVar.notify_all();
+
+            defaultBeat();
         }
         else
         {
-            if (run)
-                ++reqTimeoutCnt;
+            ++reqTimeoutCnt;
         }
 
         if (!run)
@@ -211,8 +208,17 @@ void NonBlockingBeat::beatWriter()
 
 void NonBlockingBeat::printBeatReport()
 {
+    std::size_t max, cnt;
+
+    {
+        std::lock_guard<std::mutex> lock(beatMutex);
+        max = beatReqCountMax;
+        cnt = reqTimeoutCnt;
+    }
+
     printf( "Request timeout               : %zu ms\n", reqTimeout );
-    printf( "Timeouts waiting for requests : %zu\n",   reqTimeoutCnt );
+    printf( "Timeouts waiting for requests : %zu\n",    cnt        );
+    printf( "Maximum queued requests       : %zu\n",    max        );
     defaultPrintReport();
 }
 

--- a/src/heartbeat.h
+++ b/src/heartbeat.h
@@ -114,7 +114,8 @@ public:
 private:
     std::size_t             reqTimeoutCnt;
     std::size_t             reqTimeout;
-    bool                    beatReq;
+    std::size_t             beatReqCount;
+    std::size_t             beatReqCountMax;
     std::mutex              beatMutex;
     std::condition_variable beatCondVar;
     boost::atomic<bool>     run;
@@ -122,11 +123,10 @@ private:
 
     void beatWriter();
 
-    // Helper predicate functions used for the conditional variable
+    // Helper predicate function used for the conditional variable
     // 'wait_for' methods. We need this as our old rhel6 host don't
     // support C++11 , otherwise we could have used lambda expressions.
-    bool pred()  { return beatReq;  };
-    bool predN() { return !beatReq; };
+    bool pred()  { return beatReqCount;  };
 };
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -17,6 +17,7 @@ HEADERS = central_node_bypass.h \
         time_util.h \
         timer.h \
         buffer.h \
+        queue.h \
         heartbeat.h \
         central_node_history.h \
         central_node_history_protocol.h \
@@ -39,6 +40,7 @@ central_node_engine_SRCS += timer.cc
 central_node_engine_SRCS += heartbeat.cc
 central_node_engine_SRCS += heartbeat_noop.cc
 central_node_engine_SRCS += buffer.cc
+central_node_engine_SRCS += queue.cc
 
 DEP_HEADERS  = $(HEADERS)
 

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -1,0 +1,70 @@
+#include "queue.h"
+
+template<typename T>
+Queue<T>::Queue()
+:
+    watermark(0)
+{
+}
+
+template<typename T>
+void Queue<T>::push(T val)
+{
+    {
+        std::lock_guard<std::mutex> lock(m);
+        q.push(std::move(val));
+
+        if (q.size() > watermark)
+            watermark= q.size();
+    }
+    cv.notify_one();
+}
+
+template<typename T>
+void Queue<T>::reset()
+{
+    std::lock_guard<std::mutex> lock(m);
+    std::queue<T>().swap(q);
+    watermark = 0;
+}
+
+template<typename T>
+typename Queue<T>::value_type Queue<T>::pop()
+{
+    std::unique_lock<std::mutex> lock(m);
+    cv.wait(lock, std::bind(&Queue::pred, this));
+    return pop_and_get();
+}
+
+template<typename T>
+typename Queue<T>::value_type Queue<T>::try_pop()
+{
+    std::lock_guard<std::mutex> lock(m);
+    if (q.empty())
+        return value_type();
+    return pop_and_get();
+}
+
+template<typename T>
+typename Queue<T>::value_type Queue<T>::pop_and_get()
+{
+    value_type val { std::make_shared<T>( std::move(q.front()) ) };
+    q.pop();
+    return val;
+}
+
+template<typename T>
+std::size_t Queue<T>::get_max_size() const
+{
+    std::lock_guard<std::mutex> lock(m);
+    return watermark;
+}
+
+template<typename T>
+void Queue<T>::clear_counters()
+{
+    std::lock_guard<std::mutex> lock(m);
+    watermark = 0;
+}
+
+template class Queue< std::vector<uint32_t> >;

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -33,7 +33,15 @@ typename Queue<T>::value_type Queue<T>::pop()
 {
     std::unique_lock<std::mutex> lock(m);
     cv.wait(lock, std::bind(&Queue::pred, this));
-    return pop_and_get();
+    return std::make_shared<T>( pop_and_get() );
+}
+
+template<typename T>
+void Queue<T>::pop(T& val)
+{
+    std::unique_lock<std::mutex> lock(m);
+    cv.wait(lock, std::bind(&Queue::pred, this));
+    val = pop_and_get();
 }
 
 template<typename T>
@@ -42,13 +50,13 @@ typename Queue<T>::value_type Queue<T>::try_pop()
     std::lock_guard<std::mutex> lock(m);
     if (q.empty())
         return value_type();
-    return pop_and_get();
+    return std::make_shared<T>( pop_and_get() );
 }
 
 template<typename T>
-typename Queue<T>::value_type Queue<T>::pop_and_get()
+T Queue<T>::pop_and_get()
 {
-    value_type val { std::make_shared<T>( std::move(q.front()) ) };
+    T val ( std::move(q.front()) );
     q.pop();
     return val;
 }
@@ -67,4 +75,6 @@ void Queue<T>::clear_counters()
     watermark = 0;
 }
 
+template class Queue< std::vector<uint8_t> >;
 template class Queue< std::vector<uint32_t> >;
+

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,60 @@
+#ifndef _QUEUE_H_
+#define _QUEUE_H_
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <memory>
+#include <functional>
+
+template<typename T>
+class Queue
+{
+public:
+    // Convinient typedef. This is the data type returned
+    // by the pop methods.
+    typedef std::shared_ptr<T> value_type;
+
+    Queue();
+
+    // Push a nee value to the queue.
+    void push(T val);
+
+    // Blocking call. The thread will wait (sleeping) until a value
+    // is available in the queue.
+    value_type pop();
+
+    // Non-blocking call. If not value is available, the call will
+    // return immediatelly with a null pointer.
+    value_type try_pop();
+
+    // Get the maximum value
+    std::size_t get_max_size() const;
+
+    // Clear the internal counters.
+    void clear_counters();
+
+    // Reset the queue: clear all elements in the queue, and the
+    // internal counters.
+    void reset();
+
+private:
+    std::size_t             watermark;
+    std::queue<T>           q;
+    mutable std::mutex      m;
+    std::condition_variable cv;
+
+    // Helper function to return and pop the front element
+    // from the queue, to avoid code duplication between pop()
+    // and try_pop(). It is call when we are sure there is at
+    // least one element in the queue.
+    value_type pop_and_get();
+
+    // Helper predicate function used for the conditional variable
+    // wait methods. We need this as our old rhel6 host don't
+    // support C++11 , otherwise we could have used lambda expressions.
+    bool pred() { return !q.empty(); }
+};
+
+#endif
+

--- a/src/queue.h
+++ b/src/queue.h
@@ -20,11 +20,13 @@ public:
     // Push a nee value to the queue.
     void push(T val);
 
-    // Blocking call. The thread will wait (sleeping) until a value
+    // Blocking calls. The thread will wait (sleeping) until a value
     // is available in the queue.
     value_type pop();
 
-    // Non-blocking call. If not value is available, the call will
+    void pop(T& val);
+
+    // Non-blocking calls. If not value is available, the call will
     // return immediatelly with a null pointer.
     value_type try_pop();
 
@@ -48,7 +50,7 @@ private:
     // from the queue, to avoid code duplication between pop()
     // and try_pop(). It is call when we are sure there is at
     // least one element in the queue.
-    value_type pop_and_get();
+    T pop_and_get();
 
     // Helper predicate function used for the conditional variable
     // wait methods. We need this as our old rhel6 host don't


### PR DESCRIPTION
This PR bring several improves and bug fixes to the evaluation processing pipeline, in order to fix the slow evaluation described in: https://jira.slac.stanford.edu/browse/ESLMPS-128

The main fix was to tune the different thread RT priorities, including also the kernel NIC thread priorities (not part of this repository, but instead part of the CPU boot script setup).

Additionally, I also added a new thread-safe queue class, and changed the interface between the FW reader and input processing thread, as well as be went the input processing and the mitigation writer thread from using `DataBuffer` object (a dual buffer) to this new `Queue` object. On the other hand, I also modified the `NonBlocking` policy class of the `HeartBeat` class, to use a request counter, instead of a flag. Theses changes should give the system more elasticity to absorb delays between threads, instead of blocking the whole pipeline.

Finally, I also added:
- A bug fix in the `inputProcessed()` method, which was modifying a shared variable without using the locking and condition_variable,
- Added the thread name to the `fwPCChangeThread`,
- Fixed the format in some source files to improve their readability. 
- Convert the `RELEASE_NOTES` file to Markdown format.

For more details, look here: https://jira.slac.stanford.edu/browse/ESLMPS-128