### PR TITLE
Update the `Firmware` class to support 1024 applications

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
 
+  * Increases the number of supported applications from `8` to `1024`.
   * Adjust RT priorities of all the evaluation threads as described in this
     table (note that the NIC kernel thread priorities are not set as part of
     this repository, but instead on the CPU startup script):

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -259,7 +259,7 @@ int Firmware::createRegisters()
         for (uint32_t i = 0; i < FW_NUM_APPLICATIONS; ++i)
         {
             std::stringstream appId;
-            appId << "/AppId" << i;
+            appId << "/AppId[" << i << "]/Config";
             name = base + mps + config + appId.str();
             _configSV[i] = IScalVal::create(_root->findByName(name.c_str()));
         }

--- a/src/central_node_firmware.h
+++ b/src/central_node_firmware.h
@@ -21,7 +21,7 @@
 #include <arpa/inet.h>
 #endif
 
-const uint32_t FW_NUM_APPLICATIONS = 8;
+const uint32_t FW_NUM_APPLICATIONS = 1024;
 const uint32_t FW_NUM_BEAM_CLASSES = 16;
 const uint32_t FW_NUM_MITIGATION_DEVICES = 16;
 const uint32_t FW_NUM_BEAM_DESTINATIONS = 16;


### PR DESCRIPTION
In order to support 1024 application configuration spaces, I updated the `MpsCentralNodeConfig.yaml` definition in https://github.com/slaclab/central_node_ioc/pull/11. This PR updates the `Firmware` class to support this new interface, as well as extending the supported number of application to `1024`. 

For more details see here: https://jira.slac.stanford.edu/browse/ESLMPS-123
