### PR TITLE
Add method to read the App timeout enable bits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@
 Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
+
+  * Add new method to read the application timeout enable bits:
+    `getAppTimeoutEnable()`.
+  * Add a call to `writeAppTimeoutMask()` in `setAppTimeoutEnable()` in order
+    to write to FW the configuration bits when the timeout bits are changed.
+
 * __central_node_engine-R2-0-0__:
   * Increases the number of supported applications from `8` to `1024`.
   * Adjust RT priorities of all the evaluation threads as described in this

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -313,8 +313,17 @@ void Firmware::writeAppTimeoutMask()
 
 void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable)
 {
-    if (appId < FW_NUM_APPLICATION_MASKS)
-        _applicationTimeoutMaskBitSet->set(appId, enable);
+    // Ignore invalid App IDs
+    if (appId >= FW_NUM_APPLICATION_MASKS)
+        return;
+
+    _applicationTimeoutMaskBitSet->set(appId, enable);
+    writeAppTimeoutMask();
+}
+
+bool Firmware::getAppTimeoutEnable(uint32_t appId)
+{
+    return _applicationTimeoutMaskBitSet->test(appId);
 }
 
 void Firmware::getAppTimeoutStatus()

--- a/src/central_node_firmware.h
+++ b/src/central_node_firmware.h
@@ -169,6 +169,7 @@ class Firmware {
   void setEvaluationEnable(bool enable);
   void setTimeoutEnable(bool enable);
   void setAppTimeoutEnable(uint32_t appId, bool enable);
+  bool getAppTimeoutEnable(uint32_t appId);
   bool getAppTimeoutStatus(uint32_t appId);
 
   bool getEnable();


### PR DESCRIPTION
This PR adds a new feature needed to solve: https://jira.slac.stanford.edu/browse/ESLMPS-132

It add a new method to read the application timeout enable bits.

Also, this PR adds a call to `writeAppTimeoutMask()` in `setAppTimeoutEnable()` in order to write to FW the configuration bits when the timeout bits are changed.