### PR TITLE
Do not override application timeout enable bits when setting bypasses

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@
 Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
+
+  * Only set the app timeout enable bit to true when loading the
+    configuration YAML file the first time.
+
 * __central_node_engine-R2-1-0__:
   * Add new method to read the application timeout enable bits:
     `getAppTimeoutEnable()`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@ Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
 
+  * Write the app timeout enable bits to FW all at once when they are
+    set to true by default. When they are set using the API call
+    setAppTimeoutEnable(), by default they are write to FW as well.
   * Only set the app timeout enable bit to true when loading the
     configuration YAML file the first time.
 

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -1079,6 +1079,11 @@ void MpsDb::writeFirmwareConfiguration(bool setTimeoutEnable, bool forceAomAllow
         i++;
     }
 
+    // If the app timeout were set to enable, write the configuration to FW
+    // after looping over all applications in the system
+    if (setTimeoutEnable)
+        Firmware::getInstance().writeAppTimeoutMask();
+
     // Write the timing verifying parameters for each beam class
     uint32_t time[FW_NUM_BEAM_CLASSES];
     uint32_t period[FW_NUM_BEAM_CLASSES];

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -1063,7 +1063,7 @@ void MpsDb::forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassI
     }
 }
 
-void MpsDb::writeFirmwareConfiguration(bool setTimeoutEnable, bool forceAomAllow)
+void MpsDb::writeFirmwareConfiguration(bool enableTimeout, bool forceAomAllow)
 {
     // Write configuration for each application in the system
     LOG_TRACE("DATABASE", "Writing config to firmware, num applications: " << applicationCards->size());
@@ -1072,7 +1072,7 @@ void MpsDb::writeFirmwareConfiguration(bool setTimeoutEnable, bool forceAomAllow
         card != applicationCards->end();
         ++card)
     {
-        (*card).second->writeConfiguration(setTimeoutEnable, forceAomAllow);
+        (*card).second->writeConfiguration(enableTimeout, forceAomAllow);
         Firmware::getInstance().writeConfig((*card).second->globalId, fastConfigurationBuffer +
             (*card).second->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES,
             APPLICATION_CONFIG_BUFFER_USED_SIZE_BYTES);
@@ -1081,7 +1081,7 @@ void MpsDb::writeFirmwareConfiguration(bool setTimeoutEnable, bool forceAomAllow
 
     // If the app timeout were set to enable, write the configuration to FW
     // after looping over all applications in the system
-    if (setTimeoutEnable)
+    if (enableTimeout)
         Firmware::getInstance().writeAppTimeoutMask();
 
     // Write the timing verifying parameters for each beam class

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -1063,7 +1063,7 @@ void MpsDb::forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassI
     }
 }
 
-void MpsDb::writeFirmwareConfiguration(bool forceAomAllow)
+void MpsDb::writeFirmwareConfiguration(bool setTimeoutEnable, bool forceAomAllow)
 {
     // Write configuration for each application in the system
     LOG_TRACE("DATABASE", "Writing config to firmware, num applications: " << applicationCards->size());
@@ -1072,7 +1072,7 @@ void MpsDb::writeFirmwareConfiguration(bool forceAomAllow)
         card != applicationCards->end();
         ++card)
     {
-        (*card).second->writeConfiguration(forceAomAllow);
+        (*card).second->writeConfiguration(setTimeoutEnable, forceAomAllow);
         Firmware::getInstance().writeConfig((*card).second->globalId, fastConfigurationBuffer +
             (*card).second->globalId * APPLICATION_CONFIG_BUFFER_SIZE_BYTES,
             APPLICATION_CONFIG_BUFFER_USED_SIZE_BYTES);

--- a/src/central_node_database.h
+++ b/src/central_node_database.h
@@ -185,7 +185,7 @@ class MpsDb {
   void printPCCounters() const;
 
   void forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassId=CLEAR_BEAM_CLASS);
-  void writeFirmwareConfiguration(bool forceAomAllow = false);
+  void writeFirmwareConfiguration(bool setTimeoutEnable = false, bool forceAomAllow = false);
   void unlatchAll();
   void clearMitigationBuffer();
 

--- a/src/central_node_database.h
+++ b/src/central_node_database.h
@@ -185,7 +185,7 @@ class MpsDb {
   void printPCCounters() const;
 
   void forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassId=CLEAR_BEAM_CLASS);
-  void writeFirmwareConfiguration(bool setTimeoutEnable = false, bool forceAomAllow = false);
+  void writeFirmwareConfiguration(bool enableTimeout = false, bool forceAomAllow = false);
   void unlatchAll();
   void clearMitigationBuffer();
 

--- a/src/central_node_database_tables.h
+++ b/src/central_node_database_tables.h
@@ -388,7 +388,7 @@ class DbApplicationCard : public DbEntry {
 
   DbApplicationCard();
 
-  void writeConfiguration(bool forceAomAllow = false);
+  void writeConfiguration(bool setTimeoutEnable = false, bool forceAomAllow = false);
   void writeDigitalConfiguration(bool forceAomAllow = false);
   void writeAnalogConfiguration(bool forceAomAllow = false);
 

--- a/src/central_node_database_tables.h
+++ b/src/central_node_database_tables.h
@@ -388,7 +388,7 @@ class DbApplicationCard : public DbEntry {
 
   DbApplicationCard();
 
-  void writeConfiguration(bool setTimeoutEnable = false, bool forceAomAllow = false);
+  void writeConfiguration(bool enableTimeout = false, bool forceAomAllow = false);
   void writeDigitalConfiguration(bool forceAomAllow = false);
   void writeAnalogConfiguration(bool forceAomAllow = false);
 

--- a/src/central_node_engine.cc
+++ b/src/central_node_engine.cc
@@ -117,7 +117,7 @@ int Engine::reloadConfigFromIgnore()
 
     {
         std::unique_lock<std::mutex> lock(*_mpsDb->getMutex());
-        _mpsDb->writeFirmwareConfiguration(_aomAllowWhileShutterClosed);
+        _mpsDb->writeFirmwareConfiguration(false, _aomAllowWhileShutterClosed);
     }
 
     Firmware::getInstance().setEnable(true);
@@ -254,7 +254,7 @@ int Engine::loadConfig(std::string yamlFileName, uint32_t inputUpdateTimeout)
             }
         }
 
-        _mpsDb->writeFirmwareConfiguration();
+        _mpsDb->writeFirmwareConfiguration(true);
     }
 
     LOG_TRACE("ENGINE", "Lowest beam class found: " << _lowestBeamClass->number);

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -311,14 +311,17 @@ void Firmware::writeAppTimeoutMask()
     }
 }
 
-void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable)
+void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable, bool writeFW)
 {
     // Ignore invalid App IDs
     if (appId >= FW_NUM_APPLICATION_MASKS)
         return;
 
     _applicationTimeoutMaskBitSet->set(appId, enable);
-    writeAppTimeoutMask();
+
+    // Write the configuration to FW
+    if (writeFW)
+        writeAppTimeoutMask();
 }
 
 bool Firmware::getAppTimeoutEnable(uint32_t appId)

--- a/src/central_node_firmware.cc
+++ b/src/central_node_firmware.cc
@@ -474,7 +474,7 @@ bool Firmware::getEvaluationEnable()
     return getBoolU64(_evaluationEnableSV);
 }
 
-void Firmware::setTimeoutEnable(bool enable)
+void Firmware::enableTimeout(bool enable)
 {
     setBoolU64(_timeoutEnableSV, enable);
 }

--- a/src/central_node_firmware.h
+++ b/src/central_node_firmware.h
@@ -168,7 +168,7 @@ class Firmware {
   void setTimingCheckEnable(bool enable);
   void setEvaluationEnable(bool enable);
   void setTimeoutEnable(bool enable);
-  void setAppTimeoutEnable(uint32_t appId, bool enable);
+  void setAppTimeoutEnable(uint32_t appId, bool enable, bool writeFW = true);
   bool getAppTimeoutEnable(uint32_t appId);
   bool getAppTimeoutStatus(uint32_t appId);
 

--- a/src/central_node_firmware.h
+++ b/src/central_node_firmware.h
@@ -167,7 +167,7 @@ class Firmware {
   void setSoftwareEnable(bool enable);
   void setTimingCheckEnable(bool enable);
   void setEvaluationEnable(bool enable);
-  void setTimeoutEnable(bool enable);
+  void enableTimeout(bool enable);
   void setAppTimeoutEnable(uint32_t appId, bool enable, bool writeFW = true);
   bool getAppTimeoutEnable(uint32_t appId);
   bool getAppTimeoutStatus(uint32_t appId);

--- a/src/central_node_firmware_noop.cc
+++ b/src/central_node_firmware_noop.cc
@@ -145,7 +145,7 @@ bool Firmware::getEvaluationEnable() {
   return false;
 }
 
-void Firmware::setTimeoutEnable(bool enable) {
+void Firmware::enableTimeout(bool enable) {
 }
 
 bool Firmware::getTimeoutEnable() {

--- a/src/central_node_firmware_noop.cc
+++ b/src/central_node_firmware_noop.cc
@@ -89,7 +89,7 @@ int Firmware::createRegisters() {
 void Firmware::writeAppTimeoutMask() {
 }
 
-void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable) {
+void Firmware::setAppTimeoutEnable(uint32_t appId, bool enable, bool writeFW) {
 }
 
 void Firmware::getAppTimeoutStatus() {

--- a/src/central_node_inputs.cc
+++ b/src/central_node_inputs.cc
@@ -329,7 +329,7 @@ void DbApplicationCard::updateInputs() {
 /**
  *
  */
-void DbApplicationCard::writeConfiguration(bool setTimeoutEnable, bool forceAomAllow) {
+void DbApplicationCard::writeConfiguration(bool enableTimeout, bool forceAomAllow) {
   if (digitalDevices) {
     writeDigitalConfiguration(forceAomAllow);
   }
@@ -342,8 +342,8 @@ void DbApplicationCard::writeConfiguration(bool setTimeoutEnable, bool forceAomA
     //	      << " (Id: " << this->id << ")" << std::endl;
     return;
   }
-  // Enable application timeout mask
-  if (setTimeoutEnable) {
+  // Enable application timeout
+  if (enableTimeout) {
     Firmware::getInstance().setAppTimeoutEnable(globalId, true, false);
   }
 }

--- a/src/central_node_inputs.cc
+++ b/src/central_node_inputs.cc
@@ -344,8 +344,7 @@ void DbApplicationCard::writeConfiguration(bool setTimeoutEnable, bool forceAomA
   }
   // Enable application timeout mask
   if (setTimeoutEnable) {
-    Firmware::getInstance().setAppTimeoutEnable(globalId, true);
-    Firmware::getInstance().writeAppTimeoutMask(); // TODO: call this only once, not one time per app
+    Firmware::getInstance().setAppTimeoutEnable(globalId, true, false);
   }
 }
 

--- a/src/central_node_inputs.cc
+++ b/src/central_node_inputs.cc
@@ -329,7 +329,7 @@ void DbApplicationCard::updateInputs() {
 /**
  *
  */
-void DbApplicationCard::writeConfiguration(bool forceAomAllow) {
+void DbApplicationCard::writeConfiguration(bool setTimeoutEnable, bool forceAomAllow) {
   if (digitalDevices) {
     writeDigitalConfiguration(forceAomAllow);
   }
@@ -343,8 +343,10 @@ void DbApplicationCard::writeConfiguration(bool forceAomAllow) {
     return;
   }
   // Enable application timeout mask
-  Firmware::getInstance().setAppTimeoutEnable(globalId, true);
-  Firmware::getInstance().writeAppTimeoutMask(); // TODO: call this only once, not one time per app
+  if (setTimeoutEnable) {
+    Firmware::getInstance().setAppTimeoutEnable(globalId, true);
+    Firmware::getInstance().writeAppTimeoutMask(); // TODO: call this only once, not one time per app
+  }
 }
 
 // Digital input configuration (total size = 1344 bits):


### PR DESCRIPTION
This PR solves https://jira.slac.stanford.edu/browse/ESLMPS-111.

Previously, when a bypass was set (and probably other conditions also trigger this event), the application enable bits were set back to `1`. With the changes in this PR, these enable bits are set to `1` only when the configuration YAML file is loaded initially, after that their state is not changed by events like setting a bypass. The enable bits can be changed using the `setAppTimeoutEnable()` API call.

This PR also makes the initial writing of these application timeout enable bit more efficient: previously the whole 32x 32-bit words were written to the FW every time an application bit was set; now the 32x 32-bit words are written only once, after all application are set. When the `setAppTimeoutEnable()` is used, the changes are written to FW by default.