### PR TITLE
ESLPS-147

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,11 +4,12 @@ Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
 * __central_node_engine-R2-3-0__:
-  * Change logMitigation fault to send to history server:
+  * Change logFault fault to send to history server:
       Fault ID
       Old Fault Value
       New Fault Value
       Allowed Class ID - will be 0 if no allowed class (no fault)
+  * Stop sending logMitigation
   * Fixed bug with forceBeamClass in setAllowedBeamClass() where the forceBeamClass would
     overwrite whatever the actual logic was trying to set.  Now final beam class is the
     lowest of the force and the logic output.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,17 @@
 Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
-# __central_node_engine-R2-2-1__:
+* __central_node_engine-R2-3-0__:
+  * Change logMitigation fault to send to history server:
+      Fault ID
+      Old Fault Value
+      New Fault Value
+      Allowed Class ID - will be 0 if no allowed class (no fault)
+  * Fixed bug with forceBeamClass in setAllowedBeamClass() where the forceBeamClass would
+    overwrite whatever the actual logic was trying to set.  Now final beam class is the
+    lowest of the force and the logic output.
+
+* __central_node_engine-R2-2-1__:
   * Correct destination mask behavior for SW logic to allow multiple bits in mask per destination
       allow mapping one to many
 

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -1047,18 +1047,15 @@ void MpsDb::forceBeamDestination(uint32_t beamDestinationId, uint32_t beamClassI
             if (beamClassIt != beamClasses->end())
             {
                 (*beamDestIt).second->setForceBeamClass((*beamClassIt).second);
-                std::cout << "Force dest["<< beamDestinationId <<"] to class [" << beamClassId << "]" << std::endl;
             }
             else
             {
                 (*beamDestIt).second->resetForceBeamClass();
-                std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
             }
         }
         else
         {
             (*beamDestIt).second->resetForceBeamClass();
-            std::cout << "Force dest["<< beamDestinationId <<"] reset" << std::endl;
         }
     }
 }

--- a/src/central_node_engine.cc
+++ b/src/central_node_engine.cc
@@ -642,8 +642,6 @@ void Engine::evaluateFaults()
         }
         if (oldFaultValue != (*fault).second->value)
         {
-            History::getInstance().logFault((*fault).second->id, oldFaultValue,
-                (*fault).second->faulted, deviceStateId);
             (*fault).second->sendUpdate = 1;
         }
 
@@ -860,11 +858,11 @@ void Engine::mitigate()
             }
         }
         if (maximumClass < 100) {
-          History::getInstance().logMitigation(sendFaultId,sendOldValue,sendValue,sendAllowClass);
+          History::getInstance().logFault(sendFaultId,sendOldValue,sendValue,sendAllowClass);
         }
         else {
           if ((*fault).second->sendUpdate) {
-            History::getInstance().logMitigation(sendFaultId,sendOldValue,sendValue,sendAllowClass);
+            History::getInstance().logFault(sendFaultId,sendOldValue,sendValue,sendAllowClass);
           }
         }
     }

--- a/src/central_node_history.cc
+++ b/src/central_node_history.cc
@@ -55,8 +55,8 @@ int History::log(HistoryMessageType type, uint32_t id, uint32_t oldValue, uint32
   return add(message);
 }
 
-int History::logFault(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t faultStateId) {
-  return log(FaultStateType, id, oldValue, newValue, faultStateId);
+int History::logFault(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t allowedClass) {
+  return log(FaultStateType, id, oldValue, newValue, allowedClass);
 }
 
 int History::logMitigation(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t allowedClass) {

--- a/src/central_node_history.cc
+++ b/src/central_node_history.cc
@@ -59,8 +59,8 @@ int History::logFault(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_
   return log(FaultStateType, id, oldValue, newValue, faultStateId);
 }
 
-int History::logMitigation(uint32_t id, uint32_t oldValue, uint32_t newValue) {
-  return log(MitigationType, id, oldValue, newValue, 0);
+int History::logMitigation(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t allowedClass) {
+  return log(MitigationType, id, oldValue, newValue, allowedClass);
 }
 
 int History::logDeviceInput(uint32_t id, uint32_t oldValue, uint32_t newValue) {

--- a/src/central_node_history.h
+++ b/src/central_node_history.h
@@ -42,7 +42,7 @@ class History {
 
   int log(HistoryMessageType type, uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t aux);
 
-  int logFault(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t faultStateId);
+  int logFault(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t allowedClass);
   int logMitigation(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t allowedClass);
   int logDeviceInput(uint32_t id, uint32_t oldValue, uint32_t newValue);
   int logAnalogDevice(uint32_t id, uint32_t oldValue, uint32_t newValue);

--- a/src/central_node_history.h
+++ b/src/central_node_history.h
@@ -43,7 +43,7 @@ class History {
   int log(HistoryMessageType type, uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t aux);
 
   int logFault(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t faultStateId);
-  int logMitigation(uint32_t id, uint32_t oldValue, uint32_t newValue);
+  int logMitigation(uint32_t id, uint32_t oldValue, uint32_t newValue, uint32_t allowedClass);
   int logDeviceInput(uint32_t id, uint32_t oldValue, uint32_t newValue);
   int logAnalogDevice(uint32_t id, uint32_t oldValue, uint32_t newValue);
   int logBypassState(uint32_t id, uint32_t oldValue, uint32_t newValue, uint16_t index);

--- a/src/central_node_inputs.cc
+++ b/src/central_node_inputs.cc
@@ -180,27 +180,26 @@ void DbAnalogDevice::update() {
     for (uint32_t i = 0; i < deviceType->numIntegrators; ++i) {
       integratorOffset = numChannelsCard * ANALOG_DEVICE_NUM_THRESHOLDS * i + channel->number * ANALOG_DEVICE_NUM_THRESHOLDS;
       for (uint32_t j = 0; j < ANALOG_DEVICE_NUM_THRESHOLDS; ++j) {
-	wasLow = getWasLow(integratorOffset + j);
-	wasHigh = getWasHigh(integratorOffset + j);
-
-	// If both are zero the Central Node has not received messages from the device, assume fault
-	// Both zeroes also mean no messages from application card in the last 360Hz period
-	if (wasLow + wasHigh == 0) {
-	  invalidValueCount++;
-	  newValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // Threshold exceeded
-	  latchedValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS));
-	}
-	else if (wasLow + wasHigh == 2) {
-	  newValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // If signal was both low and high during the 2.7ms set threshold crossed
-	  latchedValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS));
-	}
-	else if (wasHigh > 0) {
-	  newValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // Threshold exceeded
-	  latchedValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS));
-	}
-	else {
-	  newValue &= ~(1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // No threshold crossed
-	}
+	      wasLow = getWasLow(integratorOffset + j);
+	      wasHigh = getWasHigh(integratorOffset + j);
+        // If both are zero the Central Node has not received messages from the device, assume fault
+	      // Both zeroes also mean no messages from application card in the last 360Hz period
+	      if (wasLow + wasHigh == 0) {
+	        invalidValueCount++;
+	        newValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // Threshold exceeded
+	        latchedValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS));
+	      }
+	      else if (wasLow + wasHigh == 2) {
+	        newValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // If signal was both low and high during the 2.7ms set threshold crossed
+	        latchedValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS));
+	      }
+	      else if (wasHigh > 0) {
+	        newValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // Threshold exceeded
+	        latchedValue |= (1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS));
+	      }
+	      else {
+	        newValue &= ~(1 << (j + i * ANALOG_DEVICE_NUM_THRESHOLDS)); // No threshold crossed
+	      }
       }
     }
 


### PR DESCRIPTION
  * Change logFault fault to send to history server:
      Fault ID
      Old Fault Value
      New Fault Value
      Allowed Class ID - will be 0 if no allowed class (no fault)
  * Stop sending logMitigation
  * Fixed bug with forceBeamClass in setAllowedBeamClass() where the forceBeamClass would
    overwrite whatever the actual logic was trying to set.  Now final beam class is the
    lowest of the force and the logic output.