### PR TITLE
Add ignore conditions for digital devices 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,16 @@
 Release notes for the LCLS-II MPS central node engine.
 
 ## Releases:
+
+  * Add ignore conditions for digital devices to go with those in analog devices
+    * Change analogDeviceId in DbIgnoreCondition to deviceId
+    * Add digitalDevice to DbIgnoreCondition
+    * Connect either an analog or digital device to IgnoreCondition in central_node_database.cc
+    * Evaluate digitalDevice ignore conditions in central_node_engine.cc
+    * In central_node_engine.cc::mitigate(), add bit to check if a fault should be ignored:
+      * Link a fault to a device (ignore condition bool is currently stored with a device) through
+        the fault inputs tied to the fault.
+
 * __central_node_engine-R2-4-0__:
   * Update fault reporting to PVs so that the fault value is reported
   * tie latched faults to latched value of input value

--- a/src/central_node_database.cc
+++ b/src/central_node_database.cc
@@ -798,21 +798,30 @@ void MpsDb::configureIgnoreConditions()
             }
         }
 
-        uint32_t analogDeviceId = (*ignoreCondition).second->analogDeviceId;
+        uint32_t deviceId = (*ignoreCondition).second->deviceId;
         //    std::cout << "analogDeviceId=" << analogDeviceId << " ";
 
-        if (analogDeviceId != DbIgnoreCondition::INVALID_ID)
+        if (deviceId != DbIgnoreCondition::INVALID_ID)
         {
-            DbAnalogDeviceMap::iterator deviceIt = analogDevices->find(analogDeviceId);
-            if (deviceIt != analogDevices->end())
+            DbDigitalDeviceMap::iterator deviceIt = digitalDevices->find(deviceId);
+            if (deviceIt == digitalDevices->end())
             {
-                (*ignoreCondition).second->analogDevice = (*deviceIt).second;
+              // It is an analog device.  Link it to proper analog device.
+              DbAnalogDeviceMap::iterator analogDeviceIt = analogDevices->find(deviceId);
+              if (analogDeviceIt != analogDevices->end())
+              {
+                  (*ignoreCondition).second->analogDevice = (*analogDeviceIt).second;
+              }
+              else
+              {
+                  errorStream << "ERROR: Failed to configure database, invalid ID for AnalogDevice ("
+                      << deviceId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
+                  throw(DbException(errorStream.str()));
+              }
             }
             else
             {
-                errorStream << "ERROR: Failed to configure database, invalid ID for AnalogDevice ("
-                    << analogDeviceId << ") for IgnoreCondition (" <<  (*ignoreCondition).second->id << ")";
-                throw(DbException(errorStream.str()));
+              (*ignoreCondition).second->digitalDevice = (*deviceIt).second;
             }
         }
         else

--- a/src/central_node_database_tables.cc
+++ b/src/central_node_database_tables.cc
@@ -530,7 +530,7 @@ std::ostream & operator<<(std::ostream &os, DbConditionInput * const input) {
   return os;
 }
 
-DbIgnoreCondition::DbIgnoreCondition() : DbEntry(), conditionId(0), faultStateId(0), analogDeviceId(0) {
+DbIgnoreCondition::DbIgnoreCondition() : DbEntry(), conditionId(0), faultStateId(0), deviceId(0) {
 }
 
 std::ostream & operator<<(std::ostream &os, DbIgnoreCondition * const input) {

--- a/src/central_node_database_tables.h
+++ b/src/central_node_database_tables.h
@@ -227,6 +227,8 @@ class DbDigitalDevice : public DbEntry {
   std::string description;
   uint32_t evaluation;
   uint32_t cardId; // Application Card ID
+  // Faults from this devices are bypassed when ignored==true
+  bool ignored;
 
   DbDeviceInputMapPtr inputDevices; // list built after the config is loaded
 
@@ -644,13 +646,14 @@ class DbIgnoreCondition : public DbEntry {
 
   uint32_t conditionId;
   uint32_t faultStateId;
-  uint32_t analogDeviceId;
+  uint32_t deviceId;
 
   // The ignore condition can be used to ignore a fault state or an analog device
   // The analog device is used to disable a device when beam is blocked upstream, causing
   // faults from no beam
   DbFaultStatePtr faultState;
   DbAnalogDevicePtr analogDevice;
+  DbDigitalDevicePtr digitalDevice;
 
   DbIgnoreCondition();
   friend std::ostream & operator<<(std::ostream &os, DbIgnoreCondition * const input);

--- a/src/central_node_yaml.h
+++ b/src/central_node_yaml.h
@@ -583,7 +583,7 @@ namespace YAML {
 	DbIgnoreCondition *ignoreCondition = new DbIgnoreCondition();
 
 	ignoreCondition->faultStateId = DbIgnoreCondition::INVALID_ID;
-	ignoreCondition->analogDeviceId = DbIgnoreCondition::INVALID_ID;
+	ignoreCondition->deviceId = DbIgnoreCondition::INVALID_ID;
 
 	try {
 	  field = "id";
@@ -612,8 +612,8 @@ namespace YAML {
 	}
 
 	try {
-	  field = "analog_device_id";
-	  ignoreCondition->analogDeviceId = (*it)[field].as<unsigned int>();
+	  field = "device_id";
+	  ignoreCondition->deviceId = (*it)[field].as<unsigned int>();
 	  found = true;
 	} catch(YAML::InvalidNode &e) {
 	  errorStream << "ERROR: Failed to find field " << field << " for IgnoreCondition.";


### PR DESCRIPTION
  * Add ignore conditions for digital devices to go with those in analog devices
    * Change analogDeviceId in DbIgnoreCondition to deviceId
    * Add digitalDevice to DbIgnoreCondition
    * Connect either an analog or digital device to IgnoreCondition in central_node_database.cc
    * Evaluate digitalDevice ignore conditions in central_node_engine.cc
    * In central_node_engine.cc::mitigate(), add bit to check if a fault should be ignored:
      * Link a fault to a device (ignore condition bool is currently stored with a device) through the fault inputs tied to the fault.